### PR TITLE
Revert "Improving TOV solver stability with using cs2 instead of dlogp / dloge"

### DIFF
--- a/jesterTOV/eos/families.py
+++ b/jesterTOV/eos/families.py
@@ -68,7 +68,8 @@ def construct_family(eos: tuple, ndat: Int = 50, min_nsat: Float = 2) -> tuple[
     """
     # Unpack EOS
     ns, ps, hs, es, dloge_dlogps, cs2 = eos
-    eos_dict = dict(p=ps, h=hs, e=es, dloge_dlogp=dloge_dlogps, cs2=cs2)
+    eos_dict = dict(p=ps, h=hs, e=es, dloge_dlogp=dloge_dlogps)
+
     # calculate the pc_min
     pc_min = utils.interp_in_logspace(
         min_nsat * 0.16 * utils.fm_inv3_to_geometric, ns, ps

--- a/jesterTOV/ptov.py
+++ b/jesterTOV/ptov.py
@@ -79,12 +79,12 @@ def tov_ode(h, y, eos):
     ps = eos["p"]
     hs = eos["h"]
     es = eos["e"]
-    cs2s = eos["cs2"]
+    dloge_dlogps = eos["dloge_dlogp"]
     # actual equations
     r, m, H, b = y
     e = utils.interp_in_logspace(h, hs, es)
     p = utils.interp_in_logspace(h, hs, ps)
-    dedp = 1.0 / utils.interp_in_logspace(h, hs, cs2s)
+    dedp = e / p * jnp.interp(h, hs, dloge_dlogps)
 
     # evalute the sigma and dsigmadp
     sigma = sigma_func(
@@ -193,14 +193,12 @@ def tov_solver(eos, pc):
     Parameters
     ----------
     eos : dict
-        Extended EOS interpolation data containing arrays (accessed as ``eos["p"]``,
-        ``eos["h"]``, ``eos["e"]``, ``eos["cs2"]``, ``eos["dloge_dlogp"]``):
+        Extended EOS interpolation data containing:
 
-        - **p**: Pressure :math:`p` [geometric units]
-        - **h**: Specific enthalpy :math:`h` [geometric units]
-        - **e**: Energy density :math:`\varepsilon` [geometric units]
-        - **cs2**: Sound speed squared :math:`c_s^2 = dp/d\varepsilon` [dimensionless]
-        - **dloge_dlogp**: Logarithmic derivative :math:`d\ln\varepsilon/d\ln p` [dimensionless]
+        - **p**: Pressure array [geometric units]
+        - **h**: Enthalpy array [geometric units]
+        - **e**: Energy density array [geometric units]
+        - **dloge_dlogp**: Logarithmic derivative array
         - **alpha, beta, gamma**: Post-Newtonian parameters
         - **lambda_BL, lambda_DY, lambda_HB**: Theory modification parameters
     pc : float
@@ -224,11 +222,11 @@ def tov_solver(eos, pc):
     ps = eos["p"]
     hs = eos["h"]
     es = eos["e"]
-    cs2s = eos["cs2"]
+    dloge_dlogps = eos["dloge_dlogp"]
     # Central values and initial conditions
     hc = utils.interp_in_logspace(pc, ps, hs)
     ec = utils.interp_in_logspace(hc, hs, es)
-    dedp_c = 1.0 / utils.interp_in_logspace(hc, hs, cs2s)
+    dedp_c = ec / pc * jnp.interp(hc, hs, dloge_dlogps)
     dhdp_c = 1.0 / (ec + pc)
     dedh_c = dedp_c / dhdp_c
 

--- a/jesterTOV/tov.py
+++ b/jesterTOV/tov.py
@@ -51,12 +51,12 @@ def tov_ode(h, y, eos):
     ps = eos["p"]
     hs = eos["h"]
     es = eos["e"]
-    cs2s = eos["cs2"]
+    dloge_dlogps = eos["dloge_dlogp"]
     # Extract current state variables
     r, m, H, b = y
     e = utils.interp_in_logspace(h, hs, es)
     p = utils.interp_in_logspace(h, hs, ps)
-    dedp = 1.0 / utils.interp_in_logspace(h, hs, cs2s)
+    dedp = e / p * jnp.interp(h, hs, dloge_dlogps)
 
     # Metric coefficient A = 1/(1-2m/r)
     A = 1.0 / (1.0 - 2.0 * m / r)
@@ -182,11 +182,11 @@ def tov_solver(eos, pc):
     ps = eos["p"]
     hs = eos["h"]
     es = eos["e"]
-    cs2s = eos["cs2"]
+    dloge_dlogps = eos["dloge_dlogp"]
     # Central values and initial conditions
     hc = utils.interp_in_logspace(pc, ps, hs)
     ec = utils.interp_in_logspace(hc, hs, es)
-    dedp_c = 1.0 / utils.interp_in_logspace(hc, hs, cs2s)
+    dedp_c = ec / pc * jnp.interp(hc, hs, dloge_dlogps)
     dhdp_c = 1.0 / (ec + pc)
     dedh_c = dedp_c / dhdp_c
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,10 +30,8 @@ def sample_eos_dict():
     h = utils.cumtrapz(p_geo / (e_geo + p_geo), jnp.log(p_geo))
     dloge_dlogp = jnp.diff(jnp.log(e)) / jnp.diff(jnp.log(p))
     dloge_dlogp = jnp.concatenate([jnp.array([dloge_dlogp[0]]), dloge_dlogp])
-    dedp = e_geo / p_geo * dloge_dlogp
-    cs2 = 1.0 / dedp
-    eos_dict = {"p": p_geo, "h": h, "e": e_geo, "dloge_dlogp": dloge_dlogp, "cs2": cs2}
-    return eos_dict
+
+    return {"p": p_geo, "h": h, "e": e_geo, "dloge_dlogp": dloge_dlogp}
 
 
 @pytest.fixture

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -154,10 +154,8 @@ class TestTOVIntegration:
         hs = utils.cumtrapz(ps / (es + ps), jnp.log(ps))
         dloge_dlogps = jnp.diff(jnp.log(es)) / jnp.diff(jnp.log(ps))
         dloge_dlogps = jnp.concatenate([jnp.array([dloge_dlogps[0]]), dloge_dlogps])
-        dedps = es / ps * dloge_dlogps
-        cs2s = 1.0 / dedps
 
-        eos_dict = {"p": ps, "h": hs, "e": es, "dloge_dlogp": dloge_dlogps, "cs2": cs2s}
+        eos_dict = {"p": ps, "h": hs, "e": es, "dloge_dlogp": dloge_dlogps}
 
         # Test multiple central pressures
         pressure_indices = [20, 30, 40, 50, 60]
@@ -216,11 +214,9 @@ class TestTOVIntegration:
         hs = utils.cumtrapz(ps / (es + ps), jnp.log(ps))
         dloge_dlogps = jnp.diff(jnp.log(es)) / jnp.diff(jnp.log(ps))
         dloge_dlogps = jnp.concatenate([jnp.array([dloge_dlogps[0]]), dloge_dlogps])
-        dedps = es / ps * dloge_dlogps
-        cs2s = 1.0 / dedps
 
         # Standard EOS dict
-        eos_dict = {"p": ps, "h": hs, "e": es, "dloge_dlogp": dloge_dlogps, "cs2": cs2s}
+        eos_dict = {"p": ps, "h": hs, "e": es, "dloge_dlogp": dloge_dlogps}
 
         # Post-TOV EOS dict (GR limit)
         ptov_eos_dict = eos_dict.copy()


### PR DESCRIPTION
It seems jester runs suddenly slower since #48 and #49 , this is a quick test PR to checkout to for timing tests

Reverts nuclear-multimessenger-astronomy/jester#49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal equation of state data structures by updating how pressure derivatives are calculated. Public API remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->