### PR TITLE
Make validation of config fail if additional arguments are given

### DIFF
--- a/examples/inference/flowmc/NICER_J0030/config.yaml
+++ b/examples/inference/flowmc/NICER_J0030/config.yaml
@@ -48,7 +48,6 @@ sampler:
   n_global_steps: 100
   n_epochs: 30
   learning_rate: 0.001
-  step_size: 0.00001
   output_dir: "./outdir/"
 
 # Postprocessing configuration

--- a/examples/inference/spectral/prior/config.yaml
+++ b/examples/inference/spectral/prior/config.yaml
@@ -43,9 +43,7 @@ sampler:
   n_particles: 1000           # Fewer particles needed for prior sampling
   n_mcmc_steps: 5             # Fewer MCMC steps per level
   target_ess: 0.9             # Target effective sample size (90%)
-  random_walk_sigma: 0.1      # Initial sigma for Gaussian random walk TODO: needs to be gone?
-  target_acceptance: 0.5      # Target acceptance rate TODO: needs to be gone?
-  adaptation_rate: 0.3        # Adaptation rate for sigma tuning
+  random_walk_sigma: 0.1      # Sigma scaling for Gaussian random walk proposal
   n_eos_samples: 2000         # Number of EOS samples to generate
   log_prob_batch_size: 100    # Batch size for log probability evaluation
   output_dir: "./outdir/"

--- a/jesterTOV/inference/config/schema.py
+++ b/jesterTOV/inference/config/schema.py
@@ -9,7 +9,7 @@ TODO: make this automatic in CI/CD, so this note can be removed and user is not 
 This ensures the user documentation stays in sync with the actual validation rules.
 """
 
-from pydantic import BaseModel, Field, field_validator, ValidationInfo
+from pydantic import BaseModel, Field, field_validator, ValidationInfo, ConfigDict
 from typing import Literal, Dict, Any, Union, Annotated
 from pydantic import Discriminator
 
@@ -42,6 +42,8 @@ class TransformConfig(BaseModel):
     tov_solver : Literal["gr", "post", "scalar_tensor"]
         TOV solver type to use (default: "gr")
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     type: Literal["metamodel", "metamodel_cse", "spectral"]
     ndat_metamodel: int = 100
@@ -92,6 +94,8 @@ class PriorConfig(BaseModel):
     specification_file : str
         Path to .prior file specifying prior distributions
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     specification_file: str
 
@@ -191,6 +195,8 @@ class LikelihoodConfig(BaseModel):
                 Log likelihood penalty for Gamma bound violation (default: -1e10)
                 Only applies to spectral decomposition EOS (Γ ∈ [0.6, 4.5])
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     # TODO: deprecate rex for now: not implemented yet
     type: Literal[
@@ -404,6 +410,8 @@ class BaseSamplerConfig(BaseModel):
     log_prob_batch_size : int
         Batch size for computing log probabilities and generating EOS samples (default: 1000)
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     output_dir: str = "./outdir/"
     n_eos_samples: int = 10_000
@@ -688,6 +696,8 @@ class PostprocessingConfig(BaseModel):
         This matches LALSuite EOS format and JESTER HDF5 output. Missing keys handled gracefully.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     enabled: bool = True
     make_cornerplot: bool = True
     make_massradius: bool = True
@@ -723,6 +733,8 @@ class InferenceConfig(BaseModel):
     validate_only : bool
         Only validate configuration, don't run inference (default: False)
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     seed: int = 43
     transform: TransformConfig

--- a/tests/test_inference/test_config.py
+++ b/tests/test_inference/test_config.py
@@ -341,6 +341,73 @@ seed: 42
             parser.load_config(incomplete_config)
 
 
+class TestExtraFieldValidation:
+    """Test that config models reject extra/unknown fields."""
+
+    def test_transform_config_rejects_extra_fields(self):
+        """Test that TransformConfig rejects unknown fields."""
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            schema.TransformConfig(
+                type="metamodel",
+                nb_CSE=0,
+                wrong_entry=500,  # Should be rejected
+            )
+
+    def test_prior_config_rejects_extra_fields(self):
+        """Test that PriorConfig rejects unknown fields."""
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            schema.PriorConfig(
+                specification_file="test.prior",
+                invalid_param="value",  # Should be rejected
+            )
+
+    def test_likelihood_config_rejects_extra_fields(self):
+        """Test that LikelihoodConfig rejects unknown fields."""
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            schema.LikelihoodConfig(
+                type="zero",
+                enabled=True,
+                parameters={},
+                extra_field="should_fail",  # Should be rejected
+            )
+
+    def test_sampler_config_rejects_extra_fields(self):
+        """Test that FlowMCSamplerConfig rejects unknown fields."""
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            schema.FlowMCSamplerConfig(
+                type="flowmc",
+                n_chains=4,
+                n_loop_training=2,
+                n_loop_production=2,
+                invalid_option=True,  # Should be rejected
+            )
+
+    def test_postprocessing_config_rejects_extra_fields(self):
+        """Test that PostprocessingConfig rejects unknown fields."""
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            schema.PostprocessingConfig(
+                enabled=True,
+                make_cornerplot=True,
+                unknown_plot_type=True,  # Should be rejected
+            )
+
+    def test_inference_config_rejects_extra_fields(self, sample_config_dict):
+        """Test that InferenceConfig rejects unknown fields."""
+        config_dict = sample_config_dict.copy()
+        config_dict["random_invalid_field"] = "should_fail"
+
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            schema.InferenceConfig(**config_dict)
+
+    def test_nested_extra_fields_rejected(self, sample_config_dict):
+        """Test that extra fields in nested config sections are rejected."""
+        config_dict = sample_config_dict.copy()
+        config_dict["transform"]["wrong_entry"] = 500  # Should be rejected
+
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            schema.InferenceConfig(**config_dict)
+
+
 class TestConfigIntegration:
     """Integration tests for configuration system."""
 

--- a/tests/test_inference/test_integration.py
+++ b/tests/test_inference/test_integration.py
@@ -480,10 +480,8 @@ class TestEOSSampleGeneration:
                 "n_loop_production": 2,
                 "n_local_steps": 50,
                 "n_global_steps": 50,
+                "n_epochs": 30,
                 "learning_rate": 0.01,
-                "momentum": 0.9,
-                "batch_size": 10000,
-                "use_global": True,
                 "output_dir": str(temp_dir),
                 "n_eos_samples": 50,  # Request only 50 EOS samples
                 "log_prob_batch_size": 10,


### PR DESCRIPTION
I noticed that the user could pass arbitrary settings in the `config.yaml` files without triggering an error. This PR prevents that and also fixes a few config files in tests and examples that had legacy code that was removed at some point, which did not trigger a failure. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes / Configuration Updates**
  * Enforced stricter configuration schema validation to reject unknown fields, improving error detection for misconfigured setups
  * Updated example configurations to align with current sampler parameter requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->