### PR TITLE
Allow users to specify bilby result file and train the flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,7 @@ value = array.item()  # type: ignore[union-attr]
   - `priors/` - Bilby-style prior specification
   - `transforms/` - Unified JesterTransform for EOS → M-R-Λ
   - `likelihoods/` - Observational constraints (GW, NICER, Radio, ChiEFT, REX, etc.)
+  - `flows/` - Normalizing flow utilities for GW likelihoods; includes `bilby_extract.py` for extracting posteriors from bilby HDF5 results
   - `data/` - Data loading and caching
   - `samplers/` - FlowMC, SMC (RW/NUTS), Nested Sampling backends
   - `run_inference.py` - Main orchestration
@@ -233,6 +234,16 @@ uv run <command>
 
 # Install dependencies
 uv pip install <package>
+```
+
+### CLI Tools
+
+```bash
+# Run inference
+uv run run_jester_inference config.yaml
+
+# Extract GW posterior samples from a bilby result file (no bilby install needed)
+uv run jester_extract_gw_posterior_bilby result.hdf5 --output posterior.npz
 ```
 
 ### Check PR Status
@@ -350,6 +361,11 @@ jesterTOV/inference/
 │   └── generate_yaml_reference.py  # Auto-generate documentation
 ├── priors/                      # Prior specification system
 │   └── parser.py                # Parse .prior files (bilby-style Python)
+├── flows/                       # Normalizing flow utilities for GW likelihoods
+│   ├── bilby_extract.py         # Extract GW posteriors from bilby HDF5 (+ CLI entry point)
+│   ├── config.py                # FlowTrainingConfig Pydantic model
+│   ├── train_flow.py            # Flow training entry point
+│   └── flow.py                  # Flow model definition
 ├── transforms/                  # EOS → M-R-Λ transformation
 │   ├── transform.py             # JesterTransform (unified for all EOS×TOV)
 │   └── __init__.py              # Exports
@@ -400,6 +416,9 @@ JesterTransform.from_config(config.eos, config.tov)
 Validate parameters
   ├─ Check all required EOS params in prior → raise error if missing
   └─ Check all required TOV params in prior → warn if unused
+    ↓
+prepare_gw_flows(config, outdir)
+  └─ For any GW event with from_bilby_result: extract NPZ + train/cache flow
     ↓
 Load data (NICER, GW posteriors, ChiEFT, etc.)
     ↓

--- a/docs/inference/yaml_reference.md
+++ b/docs/inference/yaml_reference.md
@@ -179,7 +179,7 @@ Constrain the EOS using gravitational wave observations of binary neutron star m
 - type: "gw"
   enabled: true
   parameters:
-    events: [{"name": "GW170817", "model_dir": "./NFs/GW170817"}]  # List of GW events
+    events: [{"name": "GW170817", "nf_model_dir": "./NFs/GW170817"}]  # List of GW events (see GWEventConfig below)
     penalty_value: -99999.0  # Penalty for M > M_TOV (optional, default: -99999.0)
     N_masses_evaluation: 2000  # Number of mass samples to pre-sample (optional, default: 2000)
     N_masses_batch_size: 1000  # Batch size for processing (optional, default: 1000)
@@ -188,7 +188,9 @@ Constrain the EOS using gravitational wave observations of binary neutron star m
 
 **Field Details:**
 
-- **`events`** (`list[dict]`) - List of GW events with `name` and optional `model_dir` keys. If `model_dir` is omitted, uses preset paths.
+- **`events`** (`list[GWEventConfig]`) - List of GW event configs (see **GWEventConfig** below). Each entry must have `name`. Two modes are supported:
+  - **Pre-trained flow**: set `nf_model_dir` to point to a trained flow, or omit it to use a built-in preset.
+  - **From bilby result**: set `from_bilby_result` to the path of a bilby HDF5 result file; jester will extract posterior samples and train a flow automatically before inference.
 - **`penalty_value`** (`float`, default: `-99999.0`) - Log-likelihood penalty for masses exceeding TOV maximum mass
 - **`N_masses_evaluation`** (`int`, default: `2000`) - Number of mass samples to pre-sample from the GW posterior
 - **`N_masses_batch_size`** (`int`, default: `1000`) - Batch size for jax.lax.map processing of mass grid
@@ -198,7 +200,35 @@ Constrain the EOS using gravitational wave observations of binary neutron star m
 
 **Description:**
 
-**Default GW likelihood** (presampled version): Pre-samples masses from GW posterior for efficient evaluation. Recommended for production use.
+**Default GW likelihood** (presampled version): pre-samples masses from the GW posterior for efficient evaluation. Recommended for production use.
+
+**GWEventConfig fields** (each entry in `events`):
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | str | required | Event name, e.g. `GW170817` |
+| `nf_model_dir` | str\|null | null | Path to a pre-trained normalizing flow directory. Mutually exclusive with `from_bilby_result`. |
+| `from_bilby_result` | str\|null | null | Path to a bilby result `.hdf5` file. jester will extract posterior samples and train a flow automatically. |
+| `flow_config` | str\|null | null | Path to a `FlowTrainingConfig` YAML file for custom flow training (only valid with `from_bilby_result`). |
+| `retrain_flow` | bool | false | Force re-training even if a cached flow exists (only valid with `from_bilby_result`). |
+
+**Examples**:
+
+```yaml
+# Pre-trained flow (preset):
+events:
+  - name: GW170817
+
+# Pre-trained flow (custom path):
+events:
+  - name: GW170817
+    nf_model_dir: ./my_flow
+
+# From bilby result (auto-train):
+events:
+  - name: GW170817
+    from_bilby_result: ./GW170817_result.hdf5
+```
 
 ::::
 
@@ -210,7 +240,7 @@ Constrain the EOS using gravitational wave observations of binary neutron star m
 - type: "gw_resampled"
   enabled: true
   parameters:
-    events: [{"name": "GW170817", "model_dir": "./NFs/GW170817"}]  # List of GW events
+    events: [{"name": "GW170817", "nf_model_dir": "./NFs/GW170817"}]  # List of GW events
     penalty_value: -99999.0  # Penalty for M > M_TOV (optional, default: -99999.0)
     N_masses_evaluation: 20  # Number of masses per evaluation (optional, default: 20)
     N_masses_batch_size: 10  # Batch size for sampling (optional, default: 10)
@@ -218,7 +248,7 @@ Constrain the EOS using gravitational wave observations of binary neutron star m
 
 **Field Details:**
 
-- **`events`** (`list[dict]`) - List of GW events with `name` and optional `model_dir` keys
+- **`events`** (`list[dict]`) - List of GW events with `name` and optional `nf_model_dir` keys
 - **`penalty_value`** (`float`, default: `-99999.0`) - Log-likelihood penalty for masses exceeding TOV maximum mass
 - **`N_masses_evaluation`** (`int`, default: `20`) - Number of mass samples to draw on-the-fly per likelihood evaluation
 - **`N_masses_batch_size`** (`int`, default: `10`) - Batch size for mass sampling and processing

--- a/jesterTOV/inference/CLAUDE.md
+++ b/jesterTOV/inference/CLAUDE.md
@@ -66,12 +66,18 @@ jesterTOV/inference/
 │   └── schemas/         # Domain-specific config sub-modules
 │       ├── eos.py       #   BaseEOSConfig + concrete EOS configs
 │       ├── tov.py       #   BaseTOVConfig + GRTOVConfig
-│       ├── likelihoods.py #  All likelihood configs
+│       ├── likelihoods.py #  All likelihood configs (incl. GWEventConfig)
 │       └── samplers.py  #   All sampler configs
 │   ├── parser.py        # YAML loading
 │   └── generate_yaml_reference.py  # Auto-generate docs
 ├── priors/              # Prior specification system
 │   └── parser.py        # Parse .prior files (bilby-style Python format)
+├── flows/               # Normalizing flow utilities for GW likelihoods
+│   ├── bilby_extract.py # Extract GW posteriors from bilby HDF5 results (+ CLI)
+│   ├── config.py        # FlowTrainingConfig Pydantic model
+│   ├── train_flow.py    # Flow training entry point
+│   ├── flow.py          # Flow model definition
+│   └── __init__.py      # Exports Flow, load_model, extract_gw_posterior_from_bilby
 ├── transforms/          # Unified transform system
 │   ├── transform.py     # JesterTransform - single class for all EOS+TOV combinations
 │   └── __init__.py      # Exports JesterTransform
@@ -122,6 +128,12 @@ JesterTransform.from_config(config.eos, config.tov)
 Validate parameters
   ├─ Check all required EOS params in prior → raise error if missing
   └─ Check all required TOV params in prior → warn if unused
+    ↓
+prepare_gw_flows(config, outdir)   # no-op unless from_bilby_result events exist
+  ├─ Extract NPZ from bilby HDF5 (jester_extract_gw_posterior_bilby)
+  ├─ Train normalizing flow (FlowTrainingConfig + train_flow_from_config)
+  ├─ Hash-based cache: skip training if flow unchanged (flow_config_hash.json)
+  └─ Return updated config with resolved nf_model_dir for each event
     ↓
 Load data (NICER, GW posteriors, ChiEFT, etc.)
   ├─ Cache downloads from Zenodo
@@ -320,7 +332,11 @@ Configuration files use YAML with Pydantic validation. See `examples/inference/*
 
 **Likelihood Types** (defined in `config/schemas/likelihoods.py`, re-exported from `config/schema.py`):
 1. `GWLikelihoodConfig` - Gravitational wave events (pre-sampled)
-   - events: list of event names (e.g., ["GW170817"])
+   - `events`: list of `GWEventConfig` objects — two modes per event:
+     - **Pre-trained flow** (default): set `nf_model_dir` to a trained flow directory, or omit to use a built-in preset
+     - **From bilby result**: set `from_bilby_result` to a bilby HDF5 path; jester extracts posterior samples and trains a flow automatically via `prepare_gw_flows()` in `run_inference.py`
+   - `GWEventConfig` fields: `name` (required), `nf_model_dir`, `from_bilby_result`, `flow_config`, `retrain_flow`
+   - `from_bilby_result` and `nf_model_dir` are mutually exclusive; `flow_config`/`retrain_flow` only valid with `from_bilby_result`
 2. `GWResampledLikelihoodConfig` - GW with resampling during MCMC
 3. `NICERLikelihoodConfig` - X-ray timing
    - sources: list of sources (e.g., ["J0030", "J0740"])

--- a/jesterTOV/inference/config/generate_yaml_reference.py
+++ b/jesterTOV/inference/config/generate_yaml_reference.py
@@ -354,8 +354,8 @@ def extract_likelihoods() -> list[dict[str, Any]]:
                     "parameters": [
                         {
                             "name": "events",
-                            "example": '[{"name": "GW170817", "model_dir": "./NFs/GW170817"}]',
-                            "inline_comment": "List of GW events",
+                            "example": '[{"name": "GW170817", "nf_model_dir": "./NFs/GW170817"}]',
+                            "inline_comment": "List of GW events (see GWEventConfig below)",
                         },
                         {
                             "name": "penalty_value",
@@ -381,9 +381,17 @@ def extract_likelihoods() -> list[dict[str, Any]]:
                     "field_details": [
                         {
                             "name": "events",
-                            "type": "list[dict]",
+                            "type": "list[GWEventConfig]",
                             "default": None,
-                            "description": "List of GW events with `name` and optional `model_dir` keys. If `model_dir` is omitted, uses preset paths.",
+                            "description": (
+                                "List of GW event configs (see **GWEventConfig** below). "
+                                "Each entry must have `name`. Two modes are supported:\n"
+                                "  - **Pre-trained flow**: set `nf_model_dir` to point to a trained flow, "
+                                "or omit it to use a built-in preset.\n"
+                                "  - **From bilby result**: set `from_bilby_result` to the path of a bilby "
+                                "HDF5 result file; jester will extract posterior samples and train a flow "
+                                "automatically before inference."
+                            ),
                         },
                         {
                             "name": "penalty_value",
@@ -410,7 +418,32 @@ def extract_likelihoods() -> list[dict[str, Any]]:
                             "description": "Random seed for mass pre-sampling from GW posterior",
                         },
                     ],
-                    "description_text": "**Default GW likelihood** (presampled version): Pre-samples masses from GW posterior for efficient evaluation. Recommended for production use.",
+                    "description_text": (
+                        "**Default GW likelihood** (presampled version): pre-samples masses from "
+                        "the GW posterior for efficient evaluation. Recommended for production use.\n\n"
+                        "**GWEventConfig fields** (each entry in `events`):\n\n"
+                        "| Field | Type | Default | Description |\n"
+                        "|-------|------|---------|-------------|\n"
+                        "| `name` | str | required | Event name, e.g. `GW170817` |\n"
+                        "| `nf_model_dir` | str\\|null | null | Path to a pre-trained normalizing flow directory. Mutually exclusive with `from_bilby_result`. |\n"
+                        "| `from_bilby_result` | str\\|null | null | Path to a bilby result `.hdf5` file. jester will extract posterior samples and train a flow automatically. |\n"
+                        "| `flow_config` | str\\|null | null | Path to a `FlowTrainingConfig` YAML file for custom flow training (only valid with `from_bilby_result`). |\n"
+                        "| `retrain_flow` | bool | false | Force re-training even if a cached flow exists (only valid with `from_bilby_result`). |\n\n"
+                        "**Examples**:\n\n"
+                        "```yaml\n"
+                        "# Pre-trained flow (preset):\n"
+                        "events:\n"
+                        "  - name: GW170817\n\n"
+                        "# Pre-trained flow (custom path):\n"
+                        "events:\n"
+                        "  - name: GW170817\n"
+                        "    nf_model_dir: ./my_flow\n\n"
+                        "# From bilby result (auto-train):\n"
+                        "events:\n"
+                        "  - name: GW170817\n"
+                        "    from_bilby_result: ./GW170817_result.hdf5\n"
+                        "```"
+                    ),
                 },
                 {
                     "title": "Resampled GW Likelihood (Legacy)",
@@ -418,7 +451,7 @@ def extract_likelihoods() -> list[dict[str, Any]]:
                     "parameters": [
                         {
                             "name": "events",
-                            "example": '[{"name": "GW170817", "model_dir": "./NFs/GW170817"}]',
+                            "example": '[{"name": "GW170817", "nf_model_dir": "./NFs/GW170817"}]',
                             "inline_comment": "List of GW events",
                         },
                         {
@@ -442,7 +475,7 @@ def extract_likelihoods() -> list[dict[str, Any]]:
                             "name": "events",
                             "type": "list[dict]",
                             "default": None,
-                            "description": "List of GW events with `name` and optional `model_dir` keys",
+                            "description": "List of GW events with `name` and optional `nf_model_dir` keys",
                         },
                         {
                             "name": "penalty_value",

--- a/jesterTOV/inference/config/schema.py
+++ b/jesterTOV/inference/config/schema.py
@@ -43,6 +43,7 @@ from .schemas.tov import (
 # Likelihood schemas
 from .schemas.likelihoods import (
     BaseLikelihoodConfig,
+    GWEventConfig,
     GWLikelihoodConfig,
     GWResampledLikelihoodConfig,
     NICERLikelihoodConfig,
@@ -232,6 +233,7 @@ __all__ = [
     "TOVConfig",
     # Likelihoods
     "BaseLikelihoodConfig",
+    "GWEventConfig",
     "GWLikelihoodConfig",
     "GWResampledLikelihoodConfig",
     "NICERLikelihoodConfig",

--- a/jesterTOV/inference/config/schemas/likelihoods.py
+++ b/jesterTOV/inference/config/schemas/likelihoods.py
@@ -2,7 +2,14 @@
 
 import warnings
 from typing import Literal, Union, Annotated
-from pydantic import BaseModel, Field, field_validator, ConfigDict, Discriminator
+from pydantic import (
+    BaseModel,
+    Field,
+    field_validator,
+    model_validator,
+    ConfigDict,
+    Discriminator,
+)
 
 from jesterTOV.logging_config import get_logger
 
@@ -19,11 +26,112 @@ class BaseLikelihoodConfig(BaseModel):
     )
 
 
+class GWEventConfig(BaseModel):
+    r"""Configuration for a single GW event in the likelihood.
+
+    Two modes are supported:
+
+    **Mode 1 — pre-trained flow** (default):
+      Provide ``nf_model_dir`` or omit it to use a built-in preset.
+
+    **Mode 2 — from bilby result**:
+      Provide ``from_bilby_result`` to extract samples and train the flow
+      automatically when running :func:`~jesterTOV.inference.run_inference.main`.
+
+    The two modes are mutually exclusive: ``nf_model_dir`` and
+    ``from_bilby_result`` cannot both be set.
+
+    Examples
+    --------
+    Pre-trained flow (using preset):
+
+    .. code-block:: yaml
+
+        events:
+          - name: GW170817
+
+    Pre-trained flow (custom path):
+
+    .. code-block:: yaml
+
+        events:
+          - name: GW170817
+            nf_model_dir: ./my_flow
+
+    From bilby result:
+
+    .. code-block:: yaml
+
+        events:
+          - name: GW170817
+            from_bilby_result: ./GW170817_result.hdf5
+            flow_config: ./flow_config.yaml    # optional
+            retrain_flow: false                # optional
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(description="GW event name (e.g. 'GW170817')")
+    nf_model_dir: str | None = Field(
+        default=None,
+        description=(
+            "Path to a pre-trained normalizing flow model directory. "
+            "If omitted, uses a built-in preset for known events."
+        ),
+    )
+    from_bilby_result: str | None = Field(
+        default=None,
+        description=(
+            "Path to a bilby result HDF5 file.  When set, jester will extract "
+            "posterior samples and train a normalizing flow automatically before "
+            "running inference."
+        ),
+    )
+    flow_config: str | None = Field(
+        default=None,
+        description=(
+            "Path to a YAML file with FlowTrainingConfig overrides.  "
+            "Only meaningful when 'from_bilby_result' is set."
+        ),
+    )
+    retrain_flow: bool = Field(
+        default=False,
+        description=(
+            "Force retraining even if a cached flow already exists.  "
+            "Only meaningful when 'from_bilby_result' is set."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_mode_consistency(self) -> "GWEventConfig":
+        """Ensure that bilby mode and pre-trained mode are not mixed."""
+        if self.from_bilby_result is not None and self.nf_model_dir is not None:
+            raise ValueError(
+                "Cannot specify both 'from_bilby_result' and 'nf_model_dir'. "
+                "Use 'from_bilby_result' to extract samples and train a flow, "
+                "or 'nf_model_dir' to point to an already-trained flow."
+            )
+        if self.from_bilby_result is None:
+            if self.flow_config is not None:
+                raise ValueError(
+                    "'flow_config' is only valid when 'from_bilby_result' is provided."
+                )
+            if self.retrain_flow:
+                raise ValueError(
+                    "'retrain_flow' is only valid when 'from_bilby_result' is provided."
+                )
+        return self
+
+
 class GWLikelihoodConfig(BaseLikelihoodConfig):
-    """Gravitational wave likelihood configuration (presampled version).
+    r"""Gravitational wave likelihood configuration (presampled version).
 
     This is the default GW likelihood that pre-samples masses from the
     GW posterior for efficient evaluation during MCMC sampling.
+
+    Each entry in ``events`` is a :class:`GWEventConfig` that supports two
+    modes: using a pre-trained normalizing flow (default) or automatically
+    extracting samples from a bilby result file and training the flow.
 
     Examples
     --------
@@ -33,18 +141,19 @@ class GWLikelihoodConfig(BaseLikelihoodConfig):
           enabled: true
           events:
             - name: "GW170817"
-              model_dir: "./NFs/GW170817"
+              nf_model_dir: "./NFs/GW170817"
           penalty_value: -99999.0
           N_masses_evaluation: 2000
     """
 
     type: Literal["gw"] = Field(default="gw", description="Likelihood type identifier")
 
-    events: list[dict[str, str]] = Field(
+    events: list[GWEventConfig] = Field(
         description=(
-            "List of GW events to include. Each event must have 'name' key. "
-            "Optional 'model_dir' key specifies path to normalizing flow model. "
-            "If omitted, uses preset paths based on event name."
+            "List of GW events to include. Each event must have 'name'. "
+            "Optional 'nf_model_dir' specifies path to normalizing flow model; "
+            "if omitted, uses preset paths based on event name. "
+            "Alternatively, set 'from_bilby_result' to train a flow automatically."
         ),
         min_length=1,
     )
@@ -71,17 +180,6 @@ class GWLikelihoodConfig(BaseLikelihoodConfig):
         ge=0,
         description="Random seed for reproducible mass sampling from GW posterior",
     )
-
-    @field_validator("events")
-    @classmethod
-    def validate_events(cls, v: list[dict[str, str]]) -> list[dict[str, str]]:
-        """Validate event structure."""
-        for i, event in enumerate(v):
-            if "name" not in event:
-                raise ValueError(f"Event {i} missing required 'name' field")
-            if not isinstance(event["name"], str):
-                raise ValueError(f"Event {i} 'name' must be a string")
-        return v
 
 
 class GWResampledLikelihoodConfig(BaseLikelihoodConfig):

--- a/jesterTOV/inference/flows/__init__.py
+++ b/jesterTOV/inference/flows/__init__.py
@@ -1,5 +1,6 @@
 """Normalizing flow models for gravitational wave inference."""
 
 from .flow import Flow, load_model
+from .bilby_extract import extract_gw_posterior_from_bilby
 
-__all__ = ["Flow", "load_model"]
+__all__ = ["Flow", "load_model", "extract_gw_posterior_from_bilby"]

--- a/jesterTOV/inference/flows/bilby_extract.py
+++ b/jesterTOV/inference/flows/bilby_extract.py
@@ -1,0 +1,199 @@
+"""Extract GW posterior samples from bilby result HDF5 files.
+
+This module provides utilities to read bilby result files and extract
+the parameters needed for jester's GW likelihood: ``mass_1_source``,
+``mass_2_source``, ``lambda_1``, and ``lambda_2``.
+
+Bilby serialises its ``Result`` object to HDF5 using a recursive
+dict-to-group mapping (``recursively_save_dict_contents_to_group``).
+The ``posterior`` attribute — a pandas DataFrame
+of reweighted samples — is stored as an HDF5 group with one dataset per
+parameter column.  This is the canonical source for derived parameters such
+as ``mass_1_source`` and ``lambda_1``.
+
+Note: the file also contains a ``samples`` dataset (raw nested-sampling live
+points) and ``search_parameter_keys``, but those are unweighted sampler outputs
+and do not include derived quantities.  This module reads only the ``posterior``
+group.
+
+No bilby installation is required.
+"""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+from jesterTOV.logging_config import get_logger
+
+
+logger = get_logger("jester")
+
+# Parameters required in the final .npz output
+_REQUIRED_OUTPUT_PARAMS: list[str] = [
+    "mass_1_source",
+    "mass_2_source",
+    "lambda_1",
+    "lambda_2",
+]
+
+
+# ---------------------------------------------------------------------------
+# HDF5 reading
+# ---------------------------------------------------------------------------
+
+
+def _read_bilby_hdf5(filepath: str) -> dict[str, np.ndarray]:
+    """Read the ``posterior`` group from a bilby result HDF5 file.
+
+    Bilby stores the reweighted posterior as an HDF5 group with one dataset
+    per parameter column (``f["posterior"]["<param>"]``).  This is the layout
+    produced by ``recursively_save_dict_contents_to_group`` since bilby 1.1.0.
+
+    Parameters
+    ----------
+    filepath : str
+        Path to the bilby result ``.hdf5`` file.
+
+    Returns
+    -------
+    dict[str, np.ndarray]
+        Mapping from parameter name to 1-D array of posterior samples.
+
+    Raises
+    ------
+    ValueError
+        If the file does not contain a ``posterior`` group.
+    """
+    import h5py
+
+    with h5py.File(filepath, "r") as f:
+        if "posterior" not in f or not isinstance(f["posterior"], h5py.Group):
+            raise ValueError(
+                f"No 'posterior' group found in '{filepath}'. "
+                "Expected a bilby result file saved with bilby >= 1.1.0. "
+                f"Available top-level keys: {list(f.keys())}"
+            )
+        posterior = f["posterior"]
+        assert isinstance(posterior, h5py.Group)
+        return {key: np.array(posterior[key]) for key in posterior.keys()}  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def extract_gw_posterior_from_bilby(
+    bilby_result_file: str,
+    output_file: str | None = None,
+) -> str:
+    """Extract GW posterior samples from a bilby result HDF5 file.
+
+    Reads ``mass_1_source``, ``mass_2_source``, ``lambda_1``, and
+    ``lambda_2`` from a bilby result file and saves them as a ``.npz`` file
+    suitable for use with :class:`~jesterTOV.inference.flows.config.FlowTrainingConfig`.
+
+    All four parameters must be present in the bilby result file.  Bilby
+    writes them directly for BNS analyses, so no parameter conversion is
+    performed here.
+
+    Parameters
+    ----------
+    bilby_result_file : str
+        Path to bilby result ``.hdf5`` file.
+    output_file : str | None
+        Output ``.npz`` path.  Defaults to the same directory as the input
+        with a ``_gw_jester_posterior.npz`` suffix appended to the stem.
+
+    Returns
+    -------
+    str
+        Path to the saved ``.npz`` file.
+
+    Raises
+    ------
+    KeyError
+        If a required parameter is absent from the bilby result file.
+    ValueError
+        If the HDF5 file does not contain a ``posterior`` group.
+    """
+    bilby_result_file = str(bilby_result_file)
+
+    # Determine default output path
+    if output_file is None:
+        stem = Path(bilby_result_file).stem
+        output_file = str(
+            Path(bilby_result_file).parent / f"{stem}_gw_jester_posterior.npz"
+        )
+
+    logger.info(f"Reading bilby result from {bilby_result_file}")
+    params = _read_bilby_hdf5(bilby_result_file)
+    logger.info(f"Found {len(next(iter(params.values())))} posterior samples")
+    logger.info(f"Available parameters: {sorted(params.keys())}")
+
+    # Validate required output parameters
+    for key in _REQUIRED_OUTPUT_PARAMS:
+        if key not in params:
+            raise KeyError(
+                f"Required parameter '{key}' not found in bilby result file "
+                f"'{bilby_result_file}'. "
+                f"Available parameters: {sorted(params.keys())}"
+            )
+
+    # Ensure output directory exists
+    Path(output_file).parent.mkdir(parents=True, exist_ok=True)
+
+    # Save NPZ with exactly the required keys
+    np.savez(
+        output_file,
+        mass_1_source=params["mass_1_source"],
+        mass_2_source=params["mass_2_source"],
+        lambda_1=params["lambda_1"],
+        lambda_2=params["lambda_2"],
+    )
+
+    logger.info(f"Saved GW posterior samples to {output_file}")
+    return str(output_file)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Command-line interface for extracting GW posteriors from bilby results.
+
+    Usage::
+
+        jester_extract_gw_posterior_bilby result.hdf5 [--output out.npz]
+    """
+    parser = argparse.ArgumentParser(
+        prog="jester_extract_gw_posterior_bilby",
+        description=(
+            "Extract mass_1_source, mass_2_source, lambda_1, lambda_2 from a "
+            "bilby result HDF5 file and save them as a .npz file for use with "
+            "jester's GW flow training pipeline."
+        ),
+    )
+    parser.add_argument(
+        "bilby_result_file",
+        type=str,
+        help="Path to bilby HDF5 result file",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help=(
+            "Output .npz file path.  Defaults to the same directory as the "
+            "input with '_gw_jester_posterior.npz' appended to the stem."
+        ),
+    )
+    args = parser.parse_args()
+    output_path = extract_gw_posterior_from_bilby(
+        bilby_result_file=args.bilby_result_file,
+        output_file=args.output,
+    )
+    logger.info(f"Saved: {output_path}")

--- a/jesterTOV/inference/flows/train_flow.py
+++ b/jesterTOV/inference/flows/train_flow.py
@@ -96,8 +96,11 @@ import numpy as np
 from jax import Array
 from flowjax.train import fit_to_data
 
+from jesterTOV.logging_config import get_logger
 from .config import FlowTrainingConfig
 from .flow import create_flow
+
+logger = get_logger("jester")
 
 
 def load_posterior(
@@ -148,12 +151,12 @@ def load_posterior(
     if n_samples_total > max_samples:
         downsample_factor = int(np.ceil(n_samples_total / max_samples))
         data = data[::downsample_factor]
-        print(
+        logger.info(
             f"Downsampled from {n_samples_total} to {data.shape[0]} samples "
             f"(factor: {downsample_factor})"
         )
     else:
-        print(f"Using all {n_samples_total} samples")
+        logger.info(f"Using all {n_samples_total} samples")
 
     metadata = {
         "n_samples_total": n_samples_total,
@@ -290,9 +293,9 @@ def train_flow(
         trained_flow: Trained flow model
         losses: Dictionary with 'train' and 'val' loss arrays
     """
-    print(f"Training flow for up to {max_epochs} epochs...")
-    print(f"Using {val_prop:.1%} of data for validation")
-    print(f"Batch size: {batch_size}")
+    logger.info(f"Training flow for up to {max_epochs} epochs...")
+    logger.info(f"Using {val_prop:.1%} of data for validation")
+    logger.info(f"Batch size: {batch_size}")
     trained_flow, losses = fit_to_data(
         key=key,
         dist=flow,
@@ -303,7 +306,7 @@ def train_flow(
         val_prop=val_prop,
         batch_size=batch_size,
     )
-    print(f"Training completed after {len(losses['train'])} epochs")
+    logger.info(f"Training completed after {len(losses['train'])} epochs")
     return trained_flow, losses
 
 
@@ -326,18 +329,18 @@ def save_model(
 
     # Save model weights
     weights_path = os.path.join(output_dir, "flow_weights.eqx")
-    print(f"Saving model weights to {weights_path}")
+    logger.info(f"Saving model weights to {weights_path}")
     eqx.tree_serialise_leaves(weights_path, flow)
 
     # Save architecture kwargs
     kwargs_path = os.path.join(output_dir, "flow_kwargs.json")
-    print(f"Saving flow kwargs to {kwargs_path}")
+    logger.info(f"Saving flow kwargs to {kwargs_path}")
     with open(kwargs_path, "w") as f:
         json.dump(flow_kwargs, f, indent=2)
 
     # Save metadata
     metadata_path = os.path.join(output_dir, "metadata.json")
-    print(f"Saving metadata to {metadata_path}")
+    logger.info(f"Saving metadata to {metadata_path}")
     with open(metadata_path, "w") as f:
         json.dump(metadata, f, indent=2)
 
@@ -347,7 +350,7 @@ def plot_losses(losses: Mapping[str, np.ndarray | list], output_path: str) -> No
     try:
         import matplotlib.pyplot as plt
     except ImportError:
-        print("Warning: matplotlib not available, skipping loss plot")
+        logger.warning("matplotlib not available, skipping loss plot")
         return
 
     plt.figure(figsize=(10, 6))
@@ -360,7 +363,7 @@ def plot_losses(losses: Mapping[str, np.ndarray | list], output_path: str) -> No
     plt.tight_layout()
     plt.savefig(output_path, dpi=150)
     plt.close()
-    print(f"Saved loss plot to {output_path}")
+    logger.info(f"Saved loss plot to {output_path}")
 
 
 def plot_corner(
@@ -381,7 +384,7 @@ def plot_corner(
         import corner
         import matplotlib.pyplot as plt
     except ImportError:
-        print("Warning: corner package not available, skipping corner plot")
+        logger.warning("corner package not available, skipping corner plot")
         return
 
     hist_kwargs = {"color": "blue", "density": True}
@@ -427,7 +430,7 @@ def plot_corner(
 
     plt.savefig(output_path, dpi=150, bbox_inches="tight")
     plt.close()
-    print(f"Saved corner plot to {output_path}")
+    logger.info(f"Saved corner plot to {output_path}")
 
 
 def train_flow_from_config(config: FlowTrainingConfig) -> None:
@@ -437,49 +440,49 @@ def train_flow_from_config(config: FlowTrainingConfig) -> None:
     Args:
         config: FlowTrainingConfig with all training parameters
     """
-    # Print configuration
-    print("=" * 60)
-    print("Normalizing Flow Training")
-    print("=" * 60)
-    print(f"Posterior file: {config.posterior_file}")
-    print(f"Output directory: {config.output_dir}")
-    print(f"Parameter names: {config.parameter_names}")
-    print(f"Max samples: {config.max_samples}")
-    print(f"Flow type: {config.flow_type}")
-    print(f"NN depth: {config.nn_depth}")
-    print(f"NN block dim: {config.nn_block_dim}")
-    print(f"NN width: {config.nn_width}")
-    print(f"Flow layers: {config.flow_layers}")
-    print(f"Invert: {config.invert}")
-    print(f"Cond dim: {config.cond_dim}")
-    print(f"Transformer: {config.transformer}")
-    print(f"Transformer knots: {config.transformer_knots}")
-    print(f"Transformer interval: {config.transformer_interval}")
-    print(f"Standardize: {config.standardize}")
-    print(f"Standardization method: {config.standardization_method}")
-    print(f"Max epochs: {config.num_epochs}")
-    print(f"Learning rate: {config.learning_rate}")
-    print(f"Patience: {config.max_patience}")
-    print(f"Val proportion: {config.val_prop}")
-    print(f"Seed: {config.seed}")
-    print("=" * 60)
+    # Log configuration
+    logger.info("=" * 60)
+    logger.info("Normalizing Flow Training")
+    logger.info("=" * 60)
+    logger.info(f"Posterior file: {config.posterior_file}")
+    logger.info(f"Output directory: {config.output_dir}")
+    logger.info(f"Parameter names: {config.parameter_names}")
+    logger.info(f"Max samples: {config.max_samples}")
+    logger.info(f"Flow type: {config.flow_type}")
+    logger.info(f"NN depth: {config.nn_depth}")
+    logger.info(f"NN block dim: {config.nn_block_dim}")
+    logger.info(f"NN width: {config.nn_width}")
+    logger.info(f"Flow layers: {config.flow_layers}")
+    logger.info(f"Invert: {config.invert}")
+    logger.info(f"Cond dim: {config.cond_dim}")
+    logger.info(f"Transformer: {config.transformer}")
+    logger.info(f"Transformer knots: {config.transformer_knots}")
+    logger.info(f"Transformer interval: {config.transformer_interval}")
+    logger.info(f"Standardize: {config.standardize}")
+    logger.info(f"Standardization method: {config.standardization_method}")
+    logger.info(f"Max epochs: {config.num_epochs}")
+    logger.info(f"Learning rate: {config.learning_rate}")
+    logger.info(f"Patience: {config.max_patience}")
+    logger.info(f"Val proportion: {config.val_prop}")
+    logger.info(f"Seed: {config.seed}")
+    logger.info("=" * 60)
 
     # Check for GPU
-    print(f"JAX devices: {jax.devices()}")
+    logger.info(f"JAX devices: {jax.devices()}")
 
     # Load data
-    print("\n[1/5] Loading posterior samples...")
+    logger.info("[1/5] Loading posterior samples...")
     data, load_metadata = load_posterior(
         config.posterior_file,
         parameter_names=config.parameter_names,
         max_samples=config.max_samples,
     )
     parameter_names = load_metadata["parameter_names"]
-    print(f"Data shape: {data.shape}")
-    print(f"Parameters: {parameter_names}")
-    print("Original data ranges:")
+    logger.info(f"Data shape: {data.shape}")
+    logger.info(f"Parameters: {parameter_names}")
+    logger.info("Original data ranges:")
     for i, name in enumerate(parameter_names):
-        print(f"  {name}: [{data[:, i].min():.3f}, {data[:, i].max():.3f}]")
+        logger.info(f"  {name}: [{data[:, i].min():.3f}, {data[:, i].max():.3f}]")
 
     # Keep copy of original data for corner plot
     original_data = data.copy()
@@ -488,27 +491,29 @@ def train_flow_from_config(config: FlowTrainingConfig) -> None:
     data_statistics = None
     if config.standardize:
         if config.standardization_method == "zscore":
-            print("\nStandardizing data using z-score (mean=0, std=1)...")
+            logger.info("Standardizing data using z-score (mean=0, std=1)...")
             data, data_statistics = standardize_data_zscore(data)
-            print("Standardized data statistics:")
+            logger.info("Standardized data statistics:")
             for i, name in enumerate(parameter_names):
-                print(
+                logger.info(
                     f"  {name}: mean={data[:, i].mean():.3f}, std={data[:, i].std():.3f}"
                 )
-            print("Data mean and std saved for inverse transformation")
+            logger.info("Data mean and std saved for inverse transformation")
         else:  # minmax
-            print("\nStandardizing data using min-max [0, 1] scaling...")
+            logger.info("Standardizing data using min-max [0, 1] scaling...")
             data, data_statistics = standardize_data_minmax(data)
-            print("Standardized data ranges:")
+            logger.info("Standardized data ranges:")
             for i, name in enumerate(parameter_names):
-                print(f"  {name}: [{data[:, i].min():.3f}, {data[:, i].max():.3f}]")
-            print("Data bounds saved for inverse transformation")
+                logger.info(
+                    f"  {name}: [{data[:, i].min():.3f}, {data[:, i].max():.3f}]"
+                )
+            logger.info("Data bounds saved for inverse transformation")
 
     # Create flow
-    print("\n[2/5] Creating flow architecture...")
+    logger.info("[2/5] Creating flow architecture...")
     flow_key, train_key, sample_key = jax.random.split(jax.random.key(config.seed), 3)
     dim = data.shape[1]  # Infer dimensionality from data
-    print(f"Flow dimensionality: {dim}D")
+    logger.info(f"Flow dimensionality: {dim}D")
     flow = create_flow(
         key=flow_key,
         dim=dim,
@@ -525,8 +530,8 @@ def train_flow_from_config(config: FlowTrainingConfig) -> None:
     )
 
     # Train flow
-    print("\n[3/5] Training flow...")
-    print(f"Training dataset shape: {data.shape}")
+    logger.info("[3/5] Training flow...")
+    logger.info(f"Training dataset shape: {data.shape}")
     trained_flow, losses = train_flow(
         flow,
         data,
@@ -537,11 +542,11 @@ def train_flow_from_config(config: FlowTrainingConfig) -> None:
         val_prop=config.val_prop,
         batch_size=config.batch_size,
     )
-    print(f"Final train loss: {losses['train'][-1]:.4f}")
-    print(f"Final val loss: {losses['val'][-1]:.4f}")
+    logger.info(f"Final train loss: {losses['train'][-1]:.4f}")
+    logger.info(f"Final val loss: {losses['val'][-1]:.4f}")
 
     # Save model
-    print("\n[4/5] Saving model...")
+    logger.info("[4/5] Saving model...")
     flow_kwargs = {
         "flow_type": config.flow_type,
         "nn_depth": config.nn_depth,
@@ -590,7 +595,7 @@ def train_flow_from_config(config: FlowTrainingConfig) -> None:
     save_model(trained_flow, config.output_dir, flow_kwargs, metadata)
 
     # Generate plots
-    print("\n[5/5] Generating plots...")
+    logger.info("[5/5] Generating plots...")
 
     # Create figures subdirectory
     figures_dir = os.path.join(config.output_dir, "figures")
@@ -625,28 +630,30 @@ def train_flow_from_config(config: FlowTrainingConfig) -> None:
                 original_data, flow_samples_np, corner_path, labels=parameter_names
             )
         except Exception as e:
-            print(
-                f"Warning: Corner plot generation failed, skipping. Error: {type(e).__name__}"
+            logger.warning(
+                f"Corner plot generation failed, skipping. Error: {type(e).__name__}"
             )
 
-    print("\n" + "=" * 60)
-    print("Training complete!")
-    print(f"Model saved to: {config.output_dir}")
-    print(f"Figures saved to: {os.path.join(config.output_dir, 'figures')}")
-    print("=" * 60)
-    print("\nTo use the trained flow:")
-    print(">>> from jesterTOV.inference.flows.flow import Flow")
-    print(f">>> flow = Flow.from_directory('{config.output_dir}')")
-    print(">>> samples = flow.sample(jax.random.key(0), (1000,))")
+    logger.info("=" * 60)
+    logger.info("Training complete!")
+    logger.info(f"Model saved to: {config.output_dir}")
+    logger.info(f"Figures saved to: {os.path.join(config.output_dir, 'figures')}")
+    logger.info("=" * 60)
+    logger.info("To use the trained flow:")
+    logger.info(">>> from jesterTOV.inference.flows.flow import Flow")
+    logger.info(f">>> flow = Flow.from_directory('{config.output_dir}')")
+    logger.info(">>> samples = flow.sample(jax.random.key(0), (1000,))")
     if config.standardize:
-        print(">>> # Samples are automatically rescaled to original domain")
-    print("=" * 60)
+        logger.info(">>> # Samples are automatically rescaled to original domain")
+    logger.info("=" * 60)
 
 
 def main():
     """Main entry point for training script."""
     if len(sys.argv) < 2:
-        print("Usage: python -m jesterTOV.inference.flows.train_flow <config.yaml>")
+        logger.error(
+            "Usage: python -m jesterTOV.inference.flows.train_flow <config.yaml>"
+        )
         sys.exit(1)
 
     config_path = Path(sys.argv[1])

--- a/jesterTOV/inference/likelihoods/factory.py
+++ b/jesterTOV/inference/likelihoods/factory.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from ..config.schema import (
     LikelihoodConfig,
+    GWEventConfig,
     GWLikelihoodConfig,
     GWResampledLikelihoodConfig,
     NICERLikelihoodConfig,
@@ -39,40 +40,39 @@ GW_EVENT_PRESETS = {
 }
 
 
-def get_gw_model_dir(event_name: str, model_dir: str | None) -> str:
+def get_gw_model_dir(event: GWEventConfig) -> str:
     """
-    Get model directory for GW event, using presets if path is not provided.
+    Get model directory for a GW event config, using presets if no path is provided.
 
     Parameters
     ----------
-    event_name : str
-        Name of the GW event (case-insensitive)
-    model_dir : str | None
-        User-provided model directory, or None/empty string to use preset
+    event : GWEventConfig
+        Typed GW event configuration.
 
     Returns
     -------
     str
-        Absolute path to model directory
+        Absolute path to model directory.
 
     Raises
     ------
     ValueError
-        If model_dir is not provided and event is not in presets
+        If ``nf_model_dir`` is not provided and the event is not in presets.
     """
+    event_name = event.name
     # Normalize event name to uppercase for preset lookup
     event_name_upper = event_name.upper()
 
-    # If model_dir is provided and not empty, use it directly
-    if model_dir:
-        return str(Path(model_dir).resolve())
+    # If nf_model_dir is provided and not empty, use it directly
+    if event.nf_model_dir:
+        return str(Path(event.nf_model_dir).resolve())
 
     # Check if event is in presets
     if event_name_upper not in GW_EVENT_PRESETS:
         raise ValueError(
-            f"No model_dir provided for event '{event_name}' and event is not in presets. "
+            f"No nf_model_dir provided for event '{event_name}' and event is not in presets. "
             f"Available presets: {list(GW_EVENT_PRESETS.keys())}. "
-            f"Please provide model_dir explicitly in the configuration."
+            f"Please provide nf_model_dir explicitly in the configuration."
         )
 
     # Get preset path and convert to absolute
@@ -83,7 +83,7 @@ def get_gw_model_dir(event_name: str, model_dir: str | None) -> str:
 
     # Log warning that we're using default path
     logger.warning(
-        f"No model_dir provided for event '{event_name}'. "
+        f"No nf_model_dir provided for event '{event_name}'. "
         f"Using default preset path: {model_dir_abs}"
     )
 
@@ -226,12 +226,10 @@ def create_combined_likelihood(
                 # Create one GWLikelihood (presampled) per event
                 for event in config.events:
                     # Get model directory (use preset if not provided)
-                    model_dir = get_gw_model_dir(
-                        event_name=event["name"], model_dir=event.get("model_dir")
-                    )
+                    model_dir = get_gw_model_dir(event)
 
                     gw_likelihood = GWLikelihood(
-                        event_name=event["name"],
+                        event_name=event.name,
                         model_dir=model_dir,
                         penalty_value=config.penalty_value,
                         N_masses_evaluation=config.N_masses_evaluation,
@@ -245,8 +243,12 @@ def create_combined_likelihood(
                 # Create one GWLikelihoodResampled per event
                 for event in config.events:
                     # Get model directory (use preset if not provided)
+                    # GWResampledLikelihoodConfig still uses dict[str, str] events
                     model_dir = get_gw_model_dir(
-                        event_name=event["name"], model_dir=event.get("model_dir")
+                        GWEventConfig(
+                            name=event["name"],
+                            nf_model_dir=event.get("model_dir"),
+                        )
                     )
 
                     gw_likelihood = GWLikelihoodResampled(

--- a/jesterTOV/inference/run_inference.py
+++ b/jesterTOV/inference/run_inference.py
@@ -20,6 +20,8 @@ from .config.schema import (
     InferenceConfig,
     MetamodelCSEEOSConfig,
     BaseMetamodelEOSConfig,
+    GWLikelihoodConfig,
+    GWEventConfig,
 )
 from .priors.parser import parse_prior_file
 from .base.prior import CombinePrior
@@ -218,6 +220,156 @@ def setup_transform(
             )
 
     return transform
+
+
+def prepare_gw_flows(config: InferenceConfig, outdir: Path) -> InferenceConfig:
+    """Prepare normalizing flows for GW events that use ``from_bilby_result`` mode.
+
+    For each enabled :class:`~jesterTOV.inference.config.schema.GWLikelihoodConfig`
+    with events in bilby mode, this function:
+
+    1. Resolves the ``nf_model_dir`` to ``{outdir}/gw_flow_cache/{event.name}``.
+    2. Extracts posterior samples from the bilby HDF5 result file (cached).
+    3. Trains a normalizing flow (with config-hash-based cache invalidation).
+    4. Replaces the bilby-mode event with a pre-trained-flow-mode event.
+
+    This is a no-op if no ``GWLikelihoodConfig`` events use ``from_bilby_result``.
+
+    Parameters
+    ----------
+    config : InferenceConfig
+        Current inference configuration.
+    outdir : Path
+        Run output directory (flows are cached under ``{outdir}/gw_flow_cache/``).
+
+    Returns
+    -------
+    InferenceConfig
+        Updated config where all GW events point to a pre-trained flow directory.
+    """
+    import hashlib
+    import shutil
+
+    from .flows.bilby_extract import extract_gw_posterior_from_bilby
+    from .flows.train_flow import train_flow_from_config
+    from .flows.config import FlowTrainingConfig
+
+    logger.info("Checking to prepare GW normalizing flows...")
+    updated_likelihoods = list(config.likelihoods)
+    any_changes = False
+
+    for lk_idx, lk_config in enumerate(config.likelihoods):
+        if not isinstance(lk_config, GWLikelihoodConfig) or not lk_config.enabled:
+            continue
+
+        bilby_events = [e for e in lk_config.events if e.from_bilby_result is not None]
+        if not bilby_events:
+            continue
+
+        updated_events = list(lk_config.events)
+        for ev_idx, event in enumerate(lk_config.events):
+            if event.from_bilby_result is None:
+                continue
+
+            # 1. Resolve nf_model_dir
+            nf_model_dir = outdir / "gw_flow_cache" / event.name
+            nf_model_dir.mkdir(parents=True, exist_ok=True)
+
+            # 2. Extract NPZ from bilby HDF5
+            npz_path = nf_model_dir / "posterior_samples.npz"
+            if not npz_path.exists():
+                logger.info(
+                    f"Extracting GW posterior for '{event.name}' from "
+                    f"{event.from_bilby_result}"
+                )
+                extract_gw_posterior_from_bilby(
+                    bilby_result_file=event.from_bilby_result,
+                    output_file=str(npz_path),
+                )
+            else:
+                logger.info(
+                    f"Using cached posterior samples for '{event.name}' at {npz_path}"
+                )
+
+            # 3. Build FlowTrainingConfig
+            fixed_fields = {
+                "posterior_file": str(npz_path),
+                "parameter_names": [
+                    "mass_1_source",
+                    "mass_2_source",
+                    "lambda_1",
+                    "lambda_2",
+                ],
+                "output_dir": str(nf_model_dir),
+            }
+            if event.flow_config:
+                # If there is a flow_config, use it as a base and override the fixed fields (e.g., to allow custom training settings like n_epochs or batch_size)
+                ft_config = FlowTrainingConfig.from_yaml(event.flow_config)
+                ft_config = ft_config.model_copy(update=fixed_fields)
+            else:
+                # No flow_config provided, use defaults for everything except the fixed fields
+                ft_config = FlowTrainingConfig(**fixed_fields)
+
+            # 4. Check cache
+            flow_weights = nf_model_dir / "flow_weights.eqx"
+            config_hash_file = nf_model_dir / "flow_config_hash.json"
+            current_hash = hashlib.sha256(
+                ft_config.model_dump_json().encode()
+            ).hexdigest()
+
+            should_train = True
+            if flow_weights.exists() and not event.retrain_flow:
+                stored_hash: str | None = None
+                if config_hash_file.exists():
+                    stored_hash = json.loads(config_hash_file.read_text()).get("hash")
+                if stored_hash == current_hash:
+                    logger.info(
+                        f"Reusing cached flow for '{event.name}' at {nf_model_dir}"
+                    )
+                    should_train = False
+                else:
+                    logger.warning(
+                        f"Flow config changed for '{event.name}' → retraining"
+                    )
+                    shutil.rmtree(nf_model_dir)
+                    nf_model_dir.mkdir(parents=True, exist_ok=True)
+                    # Re-extract NPZ after clearing the directory
+                    if not npz_path.exists():
+                        extract_gw_posterior_from_bilby(
+                            bilby_result_file=event.from_bilby_result,
+                            output_file=str(npz_path),
+                        )
+            elif event.retrain_flow and flow_weights.exists():
+                logger.info(f"retrain_flow=True for '{event.name}' → retraining")
+                shutil.rmtree(nf_model_dir)
+                nf_model_dir.mkdir(parents=True, exist_ok=True)
+                if not npz_path.exists():
+                    extract_gw_posterior_from_bilby(
+                        bilby_result_file=event.from_bilby_result,
+                        output_file=str(npz_path),
+                    )
+
+            # 5. Train flow if needed
+            if should_train:
+                logger.info(f"Training normalizing flow for '{event.name}'...")
+                train_flow_from_config(ft_config)
+                config_hash_file.write_text(json.dumps({"hash": current_hash}))
+
+            # 6. Replace event with resolved pre-trained-flow event
+            updated_events[ev_idx] = GWEventConfig(
+                name=event.name,
+                nf_model_dir=str(nf_model_dir),
+            )
+
+        updated_likelihoods[lk_idx] = lk_config.model_copy(
+            update={"events": updated_events}
+        )
+        any_changes = True
+
+    if not any_changes:
+        return config
+
+    return config.model_copy(update={"likelihoods": updated_likelihoods})
 
 
 # TODO: remove transform second argument, as it is unused
@@ -500,6 +652,8 @@ def main(config_path: str) -> None:
     logger.info(f"  ndat_TOV: {config.tov.ndat_TOV}")
     if keep_names:
         logger.info(f"  Preserving parameters in output: {keep_names}")
+
+    config = prepare_gw_flows(config, Path(outdir))
 
     logger.info("Setting up likelihood...")
     likelihood = setup_likelihood(config, transform)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ classifiers = [
 run_jester_inference = "jesterTOV.inference.run_inference:cli_entry_point"
 run_jester_postprocessing = "jesterTOV.inference.postprocessing.postprocessing:main"
 train_jester_flow = "jesterTOV.inference.flows.train_flow:main"
+jester_extract_gw_posterior_bilby = "jesterTOV.inference.flows.bilby_extract:main"
 
 [project.optional-dependencies]
 cuda12 = ["jax[cuda12]"]

--- a/tests/test_inference/test_bilby_extract.py
+++ b/tests/test_inference/test_bilby_extract.py
@@ -1,0 +1,144 @@
+"""Tests for jesterTOV.inference.flows.bilby_extract."""
+
+import numpy as np
+import pytest
+import h5py
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Helpers to create synthetic bilby-like HDF5 files
+# ---------------------------------------------------------------------------
+
+
+def _make_new_format_hdf5(
+    path: Path,
+    params: dict[str, np.ndarray],
+) -> None:
+    """Write a new-format bilby HDF5 (posterior group) to *path*."""
+    with h5py.File(path, "w") as f:
+        grp = f.create_group("posterior")
+        for key, values in params.items():
+            grp.create_dataset(key, data=values)
+
+
+# Shared posterior data used across several tests
+N = 200
+_RNG = np.random.default_rng(0)
+
+_M1_SOURCE = _RNG.uniform(1.1, 1.6, N)
+_M2_SOURCE = _RNG.uniform(0.9, _M1_SOURCE)
+_LAMBDA_1 = _RNG.uniform(0.0, 2000.0, N)
+_LAMBDA_2 = _RNG.uniform(0.0, 2000.0, N)
+
+_FULL_PARAMS = {
+    "mass_1_source": _M1_SOURCE,
+    "mass_2_source": _M2_SOURCE,
+    "lambda_1": _LAMBDA_1,
+    "lambda_2": _LAMBDA_2,
+}
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+
+class TestReadHDF5:
+    """Tests for HDF5 file reading."""
+
+    def test_read_posterior_group(self, tmp_path: Path) -> None:
+        """posterior group is read correctly into a parameter dict."""
+        hdf5_path = tmp_path / "result.hdf5"
+        _make_new_format_hdf5(hdf5_path, _FULL_PARAMS)
+
+        from jesterTOV.inference.flows.bilby_extract import _read_bilby_hdf5
+
+        params = _read_bilby_hdf5(str(hdf5_path))
+        assert set(params.keys()) == set(_FULL_PARAMS.keys())
+        np.testing.assert_allclose(params["mass_1_source"], _M1_SOURCE)
+        np.testing.assert_allclose(params["lambda_2"], _LAMBDA_2)
+
+    def test_missing_posterior_group_raises(self, tmp_path: Path) -> None:
+        """File without a posterior group raises ValueError."""
+        hdf5_path = tmp_path / "no_posterior.hdf5"
+        # Write only a samples dataset (no posterior group)
+        with h5py.File(hdf5_path, "w") as f:
+            f.create_dataset("some_data", data=np.zeros(10))
+
+        from jesterTOV.inference.flows.bilby_extract import _read_bilby_hdf5
+
+        with pytest.raises(ValueError, match="posterior"):
+            _read_bilby_hdf5(str(hdf5_path))
+
+
+class TestExtractAPI:
+    """Tests for the extract_gw_posterior_from_bilby public function."""
+
+    def test_extract_saves_npz_with_correct_keys(self, tmp_path: Path) -> None:
+        """Output NPZ contains exactly mass_1_source, mass_2_source, lambda_1, lambda_2."""
+        hdf5_path = tmp_path / "result.hdf5"
+        _make_new_format_hdf5(hdf5_path, _FULL_PARAMS)
+
+        from jesterTOV.inference.flows.bilby_extract import (
+            extract_gw_posterior_from_bilby,
+        )
+
+        out_path = tmp_path / "posterior.npz"
+        extract_gw_posterior_from_bilby(str(hdf5_path), output_file=str(out_path))
+
+        assert out_path.exists()
+        data = np.load(out_path)
+        assert set(data.files) == {
+            "mass_1_source",
+            "mass_2_source",
+            "lambda_1",
+            "lambda_2",
+        }
+
+    def test_extract_values_match_input(self, tmp_path: Path) -> None:
+        """Values in the output NPZ exactly match the input arrays."""
+        hdf5_path = tmp_path / "result.hdf5"
+        _make_new_format_hdf5(hdf5_path, _FULL_PARAMS)
+
+        from jesterTOV.inference.flows.bilby_extract import (
+            extract_gw_posterior_from_bilby,
+        )
+
+        out_path = tmp_path / "posterior.npz"
+        extract_gw_posterior_from_bilby(str(hdf5_path), output_file=str(out_path))
+
+        data = np.load(out_path)
+        np.testing.assert_allclose(data["mass_1_source"], _M1_SOURCE)
+        np.testing.assert_allclose(data["mass_2_source"], _M2_SOURCE)
+        np.testing.assert_allclose(data["lambda_1"], _LAMBDA_1)
+        np.testing.assert_allclose(data["lambda_2"], _LAMBDA_2)
+
+    def test_extract_default_output_path(self, tmp_path: Path) -> None:
+        """Omitting output_file generates a path in the same dir with correct suffix."""
+        hdf5_path = tmp_path / "GW170817_result.hdf5"
+        _make_new_format_hdf5(hdf5_path, _FULL_PARAMS)
+
+        from jesterTOV.inference.flows.bilby_extract import (
+            extract_gw_posterior_from_bilby,
+        )
+
+        returned_path = extract_gw_posterior_from_bilby(str(hdf5_path))
+
+        expected = str(tmp_path / "GW170817_result_gw_jester_posterior.npz")
+        assert returned_path == expected
+        assert Path(returned_path).exists()
+
+    def test_extract_missing_required_param_raises(self, tmp_path: Path) -> None:
+        """Missing lambda_1 raises KeyError with a descriptive message."""
+        params_no_lambda1 = {k: v for k, v in _FULL_PARAMS.items() if k != "lambda_1"}
+        hdf5_path = tmp_path / "missing.hdf5"
+        _make_new_format_hdf5(hdf5_path, params_no_lambda1)
+
+        from jesterTOV.inference.flows.bilby_extract import (
+            extract_gw_posterior_from_bilby,
+        )
+
+        out_path = tmp_path / "out.npz"
+        with pytest.raises(KeyError, match="lambda_1"):
+            extract_gw_posterior_from_bilby(str(hdf5_path), output_file=str(out_path))

--- a/tests/test_inference/test_config.py
+++ b/tests/test_inference/test_config.py
@@ -205,19 +205,20 @@ class TestLikelihoodConfig:
         """Test GW likelihood configuration."""
         config = schema.GWLikelihoodConfig(
             enabled=True,
-            events=[{"name": "GW170817", "model_dir": "/path/to/data"}],
+            events=[{"name": "GW170817", "nf_model_dir": "/path/to/data"}],
             penalty_value=-99999.0,
             N_masses_evaluation=20,
         )
         assert config.type == "gw"
         assert len(config.events) == 1
+        assert config.events[0].nf_model_dir == "/path/to/data"
         assert config.penalty_value == -99999.0
 
     def test_gw_likelihood_missing_event_name_fails(self):
         """Test that GW likelihood without event name fails."""
-        with pytest.raises(ValidationError, match="missing required 'name' field"):
+        with pytest.raises(ValidationError):
             schema.GWLikelihoodConfig(
-                events=[{"model_dir": "/path/to/data"}],  # Missing 'name'
+                events=[{"nf_model_dir": "/path/to/data"}],  # Missing 'name'
             )
 
     def test_gw_likelihood_empty_events_fails(self):
@@ -333,7 +334,7 @@ class TestLikelihoodConfig:
         # Create type adapter for LikelihoodConfig union
         adapter = TypeAdapter(schema.LikelihoodConfig)
 
-        # Test GW likelihood
+        # Test GW likelihood with just a name (uses preset)
         gw_dict = {
             "type": "gw",
             "enabled": True,
@@ -435,7 +436,7 @@ class TestInferenceConfig:
             {
                 "type": "gw",
                 "enabled": True,
-                "events": [{"name": "GW170817", "model_dir": "/path/to/data"}],
+                "events": [{"name": "GW170817", "nf_model_dir": "/path/to/data"}],
             },
             {
                 "type": "nicer",
@@ -628,6 +629,108 @@ class TestExtraFieldValidation:
 
         with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
             schema.InferenceConfig(**config_dict)
+
+
+class TestGWEventConfig:
+    """Tests for the GWEventConfig Pydantic model."""
+
+    def test_gw_event_nf_model_dir_mode(self):
+        """Valid config with only name and nf_model_dir."""
+        event = schema.GWEventConfig(name="GW170817", nf_model_dir="./my_flow")
+        assert event.name == "GW170817"
+        assert event.nf_model_dir == "./my_flow"
+        assert event.from_bilby_result is None
+        assert event.flow_config is None
+        assert event.retrain_flow is False
+
+    def test_gw_event_name_only(self):
+        """Valid config with just name (uses preset)."""
+        event = schema.GWEventConfig(name="GW170817")
+        assert event.name == "GW170817"
+        assert event.nf_model_dir is None
+        assert event.from_bilby_result is None
+
+    def test_gw_event_bilby_mode_minimal(self):
+        """Valid config with just from_bilby_result (no flow_config, no nf_model_dir)."""
+        event = schema.GWEventConfig(
+            name="GW170817",
+            from_bilby_result="./GW170817_result.hdf5",
+        )
+        assert event.from_bilby_result == "./GW170817_result.hdf5"
+        assert event.nf_model_dir is None
+        assert event.flow_config is None
+        assert event.retrain_flow is False
+
+    def test_gw_event_bilby_mode_full(self):
+        """Valid bilby config with from_bilby_result, flow_config, and retrain_flow."""
+        event = schema.GWEventConfig(
+            name="GW170817",
+            from_bilby_result="./GW170817_result.hdf5",
+            flow_config="./flow_config.yaml",
+            retrain_flow=True,
+        )
+        assert event.from_bilby_result == "./GW170817_result.hdf5"
+        assert event.flow_config == "./flow_config.yaml"
+        assert event.retrain_flow is True
+
+    def test_gw_event_flow_config_without_bilby_raises(self):
+        """flow_config without from_bilby_result raises ValidationError."""
+        with pytest.raises(ValidationError, match="'flow_config' is only valid"):
+            schema.GWEventConfig(
+                name="GW170817",
+                flow_config="./flow_config.yaml",
+            )
+
+    def test_gw_event_retrain_flow_without_bilby_raises(self):
+        """retrain_flow=True without from_bilby_result raises ValidationError."""
+        with pytest.raises(ValidationError, match="'retrain_flow' is only valid"):
+            schema.GWEventConfig(
+                name="GW170817",
+                retrain_flow=True,
+            )
+
+    def test_gw_event_extra_field_rejected(self):
+        """Unknown field raises ValidationError (extra='forbid')."""
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            schema.GWEventConfig(  # type: ignore[call-arg]
+                name="GW170817",
+                unknown_field="bad",
+            )
+
+    def test_gw_event_both_modes_raises(self):
+        """Specifying both nf_model_dir and from_bilby_result raises ValidationError."""
+        with pytest.raises(ValidationError, match="Cannot specify both"):
+            schema.GWEventConfig(
+                name="GW170817",
+                nf_model_dir="./my_flow",
+                from_bilby_result="./result.hdf5",
+            )
+
+    def test_gw_likelihood_config_with_event_objects(self):
+        """GWLikelihoodConfig accepts a list of GWEventConfig objects."""
+        events = [
+            schema.GWEventConfig(name="GW170817"),
+            schema.GWEventConfig(name="GW190425", nf_model_dir="./my_flow"),
+        ]
+        config = schema.GWLikelihoodConfig(events=events)
+        assert len(config.events) == 2
+        assert config.events[0].name == "GW170817"
+        assert config.events[1].nf_model_dir == "./my_flow"
+
+    def test_gw_likelihood_config_from_dict_with_nf_model_dir(self):
+        """GWLikelihoodConfig constructed from YAML-style dict with nf_model_dir."""
+        config = schema.GWLikelihoodConfig(
+            events=[{"name": "GW170817", "nf_model_dir": "./flows/GW170817"}],  # type: ignore[arg-type]
+        )
+        assert config.events[0].name == "GW170817"
+        assert config.events[0].nf_model_dir == "./flows/GW170817"
+
+    def test_gw_likelihood_old_model_dir_rejected(self):
+        """Using the old 'model_dir' key (instead of 'nf_model_dir') raises ValidationError."""
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            schema.GWLikelihoodConfig(
+                events=[{"name": "GW170817", "model_dir": "./my_flow"}],  # type: ignore[arg-type]
+            )
 
 
 @pytest.mark.integration

--- a/tests/test_inference/test_likelihoods.py
+++ b/tests/test_inference/test_likelihoods.py
@@ -533,7 +533,7 @@ class TestLikelihoodFactory:
         """Test that GW likelihoods must be created via create_combined_likelihood."""
         config = schema.GWLikelihoodConfig(
             enabled=True,
-            events=[{"name": "GW170817", "model_dir": "/path/to/data"}],
+            events=[{"name": "GW170817", "nf_model_dir": "/path/to/data"}],  # type: ignore[arg-type]
         )
 
         with pytest.raises(
@@ -651,16 +651,16 @@ class TestGWEventPresets:
     """Test GW event preset path functionality."""
 
     def test_get_gw_model_dir_gw170817_preset(self):
-        """Test that GW170817 uses preset path when model_dir not provided."""
-        result = factory.get_gw_model_dir("GW170817", None)
+        """Test that GW170817 uses preset path when nf_model_dir not provided."""
+        result = factory.get_gw_model_dir(schema.GWEventConfig(name="GW170817"))
 
         # Should contain the expected path components
         assert "gw170817_xp_nrtv3" in result
         assert result.endswith("gw170817_xp_nrtv3")
 
     def test_get_gw_model_dir_gw190425_preset(self):
-        """Test that GW190425 uses preset path when model_dir not provided."""
-        result = factory.get_gw_model_dir("GW190425", None)
+        """Test that GW190425 uses preset path when nf_model_dir not provided."""
+        result = factory.get_gw_model_dir(schema.GWEventConfig(name="GW190425"))
 
         # Should contain the expected path components
         assert "gw190425_xp_nrtv3" in result
@@ -669,45 +669,47 @@ class TestGWEventPresets:
     def test_get_gw_model_dir_case_insensitive(self):
         """Test that event name matching is case-insensitive."""
         # Lowercase should work
-        result_lower = factory.get_gw_model_dir("gw170817", None)
+        result_lower = factory.get_gw_model_dir(schema.GWEventConfig(name="gw170817"))
         assert "gw170817_xp_nrtv3" in result_lower
 
         # Mixed case should work
-        result_mixed = factory.get_gw_model_dir("Gw170817", None)
+        result_mixed = factory.get_gw_model_dir(schema.GWEventConfig(name="Gw170817"))
         assert "gw170817_xp_nrtv3" in result_mixed
 
         # Uppercase should work
-        result_upper = factory.get_gw_model_dir("GW170817", None)
+        result_upper = factory.get_gw_model_dir(schema.GWEventConfig(name="GW170817"))
         assert "gw170817_xp_nrtv3" in result_upper
 
     def test_get_gw_model_dir_custom_path(self):
-        """Test that custom model_dir takes precedence over preset."""
+        """Test that custom nf_model_dir takes precedence over preset."""
         custom_path = "/custom/path/to/model"
-        result = factory.get_gw_model_dir("GW170817", custom_path)
+        result = factory.get_gw_model_dir(
+            schema.GWEventConfig(name="GW170817", nf_model_dir=custom_path)
+        )
 
         # Should use the custom path, not preset
         assert "custom/path/to/model" in result
         assert "gw170817_xp_nrtv3" not in result
 
-    def test_get_gw_model_dir_empty_string_uses_preset(self):
-        """Test that empty string for model_dir triggers preset."""
-        result = factory.get_gw_model_dir("GW170817", "")
+    def test_get_gw_model_dir_no_nf_model_dir_uses_preset(self):
+        """Test that omitting nf_model_dir triggers preset lookup."""
+        result = factory.get_gw_model_dir(schema.GWEventConfig(name="GW170817"))
 
-        # Empty string should trigger preset
+        # No nf_model_dir should trigger preset
         assert "gw170817_xp_nrtv3" in result
 
     def test_get_gw_model_dir_unknown_event_raises_error(self):
-        """Test that unknown event without model_dir raises ValueError."""
+        """Test that unknown event without nf_model_dir raises ValueError."""
         with pytest.raises(ValueError, match="not in presets"):
-            factory.get_gw_model_dir("GW999999", None)
+            factory.get_gw_model_dir(schema.GWEventConfig(name="GW999999"))
 
         # Error message should list available presets
         with pytest.raises(ValueError, match="GW170817.*GW190425"):
-            factory.get_gw_model_dir("GW999999", None)
+            factory.get_gw_model_dir(schema.GWEventConfig(name="GW999999"))
 
     def test_get_gw_model_dir_returns_absolute_path(self):
         """Test that preset paths are resolved to absolute paths."""
-        result = factory.get_gw_model_dir("GW170817", None)
+        result = factory.get_gw_model_dir(schema.GWEventConfig(name="GW170817"))
 
         # Should be an absolute path
         from pathlib import Path
@@ -719,7 +721,7 @@ class TestGWEventPresets:
         from pathlib import Path
 
         for event_name in ["GW170817", "GW190425"]:
-            model_dir = factory.get_gw_model_dir(event_name, None)
+            model_dir = factory.get_gw_model_dir(schema.GWEventConfig(name=event_name))
             model_path = Path(model_dir)
 
             # Directory should exist
@@ -736,7 +738,7 @@ class TestGWEventPresets:
         """Test that Flow can actually be loaded from GW170817 preset path."""
         from jesterTOV.inference.flows.flow import Flow
 
-        model_dir = factory.get_gw_model_dir("GW170817", None)
+        model_dir = factory.get_gw_model_dir(schema.GWEventConfig(name="GW170817"))
 
         # Should load without errors
         flow = Flow.from_directory(model_dir)
@@ -751,7 +753,7 @@ class TestGWEventPresets:
         """Test that Flow can actually be loaded from GW190425 preset path."""
         from jesterTOV.inference.flows.flow import Flow
 
-        model_dir = factory.get_gw_model_dir("GW190425", None)
+        model_dir = factory.get_gw_model_dir(schema.GWEventConfig(name="GW190425"))
 
         # Should load without errors
         flow = Flow.from_directory(model_dir)


### PR DESCRIPTION
Before, after running bilby on a BNS event, users had to be quite involved in getting to run jester on the end result with the following steps:
1. Extract `mass_1_source`, `mass_1_source`, `lambda_1`, `lambda_2` from the bilby result file
2. Train a flow on that marginal posterior
3. Pass to jester and run the jester inference engine
This PR aims to take away that burden and allow user to point directly at a bilby result file in the jester config file and train the flow on-the-fly before starting the jester inference. Users can additionally (but this is optional) specify a flow_kwargs yaml file to specify their desired hyperparameters for the flow training. The current defaults give a decent flow on one of my test injections, so keeping those fixed for now. 

Currently this assumes the bilby result file is hdf5: this might be extended to pkl files as well in the future, but need to check how crucial this is within LVK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added automatic preparation and caching of gravitational wave normalizing flows from bilby results
  * Introduced CLI tool for extracting GW posterior samples from bilby results
  * Enabled per-event GW configuration supporting two modes: pre-trained flows or automatic training from bilby outputs

* **Documentation**
  * Expanded YAML reference with detailed GW event configuration examples and field descriptions
  * Added documentation for mutually exclusive configuration modes and flow-related options

* **Configuration Changes**
  * Updated GW event configuration structure with new fields for flow management
  * Replaced legacy model references with standardized naming conventions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->