### PR TITLE
Add missing normalization to GW likelihood and make no penalty the de…

### DIFF
--- a/docs/inference/yaml_reference.md
+++ b/docs/inference/yaml_reference.md
@@ -180,7 +180,6 @@ Constrain the EOS using gravitational wave observations of binary neutron star m
   enabled: true
   parameters:
     events: [{"name": "GW170817", "nf_model_dir": "./NFs/GW170817"}]  # List of GW events (see GWEventConfig below)
-    penalty_value: -99999.0  # Penalty for M > M_TOV (optional, default: -99999.0)
     N_masses_evaluation: 2000  # Number of mass samples to pre-sample (optional, default: 2000)
     N_masses_batch_size: 1000  # Batch size for processing (optional, default: 1000)
     seed: 42  # Random seed for mass sampling (optional, default: 42)
@@ -191,7 +190,7 @@ Constrain the EOS using gravitational wave observations of binary neutron star m
 - **`events`** (`list[GWEventConfig]`) - List of GW event configs (see **GWEventConfig** below). Each entry must have `name`. Two modes are supported:
   - **Pre-trained flow**: set `nf_model_dir` to point to a trained flow, or omit it to use a built-in preset.
   - **From bilby result**: set `from_bilby_result` to the path of a bilby HDF5 result file; jester will extract posterior samples and train a flow automatically before inference.
-- **`penalty_value`** (`float`, default: `-99999.0`) - Log-likelihood penalty for masses exceeding TOV maximum mass
+- **`penalty_value`** (`float`, default: `0.0`) - Log-likelihood penalty for masses exceeding TOV maximum mass (default: 0.0, i.e. no penalty)
 - **`N_masses_evaluation`** (`int`, default: `2000`) - Number of mass samples to pre-sample from the GW posterior
 - **`N_masses_batch_size`** (`int`, default: `1000`) - Batch size for jax.lax.map processing of mass grid
 - **`seed`** (`int`, default: `42`) - Random seed for mass pre-sampling from GW posterior
@@ -241,7 +240,6 @@ events:
   enabled: true
   parameters:
     events: [{"name": "GW170817", "nf_model_dir": "./NFs/GW170817"}]  # List of GW events
-    penalty_value: -99999.0  # Penalty for M > M_TOV (optional, default: -99999.0)
     N_masses_evaluation: 20  # Number of masses per evaluation (optional, default: 20)
     N_masses_batch_size: 10  # Batch size for sampling (optional, default: 10)
 ```
@@ -249,7 +247,7 @@ events:
 **Field Details:**
 
 - **`events`** (`list[dict]`) - List of GW events with `name` and optional `nf_model_dir` keys
-- **`penalty_value`** (`float`, default: `-99999.0`) - Log-likelihood penalty for masses exceeding TOV maximum mass
+- **`penalty_value`** (`float`, default: `0.0`) - Log-likelihood penalty for masses exceeding TOV maximum mass (default: 0.0, i.e. no penalty)
 - **`N_masses_evaluation`** (`int`, default: `20`) - Number of mass samples to draw on-the-fly per likelihood evaluation
 - **`N_masses_batch_size`** (`int`, default: `10`) - Batch size for mass sampling and processing
 

--- a/examples/inference/blackjax-ns-aw/GW170817/config.yaml
+++ b/examples/inference/blackjax-ns-aw/GW170817/config.yaml
@@ -21,7 +21,6 @@ likelihoods:
   enabled: true
   events:
   - name: GW170817
-  penalty_value: -99999.0
   N_masses_evaluation: 2000
   N_masses_batch_size: 1000
   seed: 42

--- a/examples/inference/flowmc/GW170817/config.yaml
+++ b/examples/inference/flowmc/GW170817/config.yaml
@@ -21,7 +21,6 @@ likelihoods:
   enabled: true
   events:
   - name: GW170817
-  penalty_value: -99999.0
   N_masses_evaluation: 2000
   N_masses_batch_size: 1000
   seed: 42

--- a/examples/inference/smc_random_walk/GW170817/config.yaml
+++ b/examples/inference/smc_random_walk/GW170817/config.yaml
@@ -21,7 +21,6 @@ likelihoods:
   enabled: true
   events:
   - name: GW170817
-  penalty_value: -99999.0
   N_masses_evaluation: 2000
   N_masses_batch_size: 1000
   seed: 42

--- a/examples/inference/spectral/GW170817/config.yaml
+++ b/examples/inference/spectral/GW170817/config.yaml
@@ -22,7 +22,6 @@ likelihoods:
   enabled: true
   events:
   - name: GW170817
-  penalty_value: -99999.0
   N_masses_evaluation: 2000
   N_masses_batch_size: 1000
   seed: 42

--- a/jesterTOV/inference/CLAUDE.md
+++ b/jesterTOV/inference/CLAUDE.md
@@ -41,6 +41,19 @@ L_sym = UniformPrior(10.0, 200.0, parameter_names=["L_sym"])
   - For model comparison and evidence estimation
   - Needs additional testing/fixes
 
+### Changing Default Values for Likelihood Parameters
+
+When a user asks to change a default value (e.g. `penalty_value`), update **all** of the following:
+
+1. **`likelihoods/<name>.py`** — `__init__` signature default(s) and docstring(s)
+2. **`config/schemas/likelihoods.py`** — `Field(default=...)` and any docstring YAML example
+3. **`config/generate_yaml_reference.py`** — hardcoded `"example"` and `"default"` strings for the affected likelihood type(s); the generator does **not** read Pydantic defaults automatically
+4. **`docs/inference/yaml_reference.md`** — regenerate: `uv run python -m jesterTOV.inference.config.generate_yaml_reference`
+5. **`examples/inference/**/config.yaml`** — remove or update the now-redundant explicit value
+6. **`tests/test_inference/test_config.py`** — update any assertion on the old default
+
+The factory (`likelihoods/factory.py`) passes `config.<field>` through, so no change needed there.
+
 ### Inference Documentation
 - `docs/inference_index.md` - Navigation hub
 - `docs/inference_quickstart.md` - Quick start guide

--- a/jesterTOV/inference/config/generate_yaml_reference.py
+++ b/jesterTOV/inference/config/generate_yaml_reference.py
@@ -358,11 +358,6 @@ def extract_likelihoods() -> list[dict[str, Any]]:
                             "inline_comment": "List of GW events (see GWEventConfig below)",
                         },
                         {
-                            "name": "penalty_value",
-                            "example": "-99999.0",
-                            "inline_comment": "Penalty for M > M_TOV (optional, default: -99999.0)",
-                        },
-                        {
                             "name": "N_masses_evaluation",
                             "example": "2000",
                             "inline_comment": "Number of mass samples to pre-sample (optional, default: 2000)",
@@ -396,8 +391,8 @@ def extract_likelihoods() -> list[dict[str, Any]]:
                         {
                             "name": "penalty_value",
                             "type": "float",
-                            "default": "-99999.0",
-                            "description": "Log-likelihood penalty for masses exceeding TOV maximum mass",
+                            "default": "0.0",
+                            "description": "Log-likelihood penalty for masses exceeding TOV maximum mass (default: 0.0, i.e. no penalty)",
                         },
                         {
                             "name": "N_masses_evaluation",
@@ -455,11 +450,6 @@ def extract_likelihoods() -> list[dict[str, Any]]:
                             "inline_comment": "List of GW events",
                         },
                         {
-                            "name": "penalty_value",
-                            "example": "-99999.0",
-                            "inline_comment": "Penalty for M > M_TOV (optional, default: -99999.0)",
-                        },
-                        {
                             "name": "N_masses_evaluation",
                             "example": "20",
                             "inline_comment": "Number of masses per evaluation (optional, default: 20)",
@@ -480,8 +470,8 @@ def extract_likelihoods() -> list[dict[str, Any]]:
                         {
                             "name": "penalty_value",
                             "type": "float",
-                            "default": "-99999.0",
-                            "description": "Log-likelihood penalty for masses exceeding TOV maximum mass",
+                            "default": "0.0",
+                            "description": "Log-likelihood penalty for masses exceeding TOV maximum mass (default: 0.0, i.e. no penalty)",
                         },
                         {
                             "name": "N_masses_evaluation",

--- a/jesterTOV/inference/config/schemas/likelihoods.py
+++ b/jesterTOV/inference/config/schemas/likelihoods.py
@@ -142,7 +142,6 @@ class GWLikelihoodConfig(BaseLikelihoodConfig):
           events:
             - name: "GW170817"
               nf_model_dir: "./NFs/GW170817"
-          penalty_value: -99999.0
           N_masses_evaluation: 2000
     """
 
@@ -159,8 +158,8 @@ class GWLikelihoodConfig(BaseLikelihoodConfig):
     )
 
     penalty_value: float = Field(
-        default=-99999.0,
-        description="Log-likelihood penalty returned when M > M_TOV",
+        default=0.0,
+        description="Log-likelihood penalty returned when M > M_TOV (default: 0.0, i.e. no penalty)",
     )
 
     N_masses_evaluation: int = Field(
@@ -208,7 +207,7 @@ class GWResampledLikelihoodConfig(BaseLikelihoodConfig):
         min_length=1,
     )
 
-    penalty_value: float = Field(default=-99999.0)
+    penalty_value: float = Field(default=0.0)
     N_masses_evaluation: int = Field(default=20, gt=0)
     N_masses_batch_size: int = Field(default=10, gt=0)
 

--- a/jesterTOV/inference/likelihoods/gw.py
+++ b/jesterTOV/inference/likelihoods/gw.py
@@ -28,7 +28,7 @@ class GWLikelihoodResampled(LikelihoodBase):
     model_dir : str
         Path to directory containing the trained normalizing flow model
     penalty_value : float, optional
-        Penalty value for samples where masses exceed Mtov (default: -99999.0)
+        Penalty value for samples where masses exceed Mtov (default: 0.0, i.e. no penalty)
     N_masses_evaluation : int, optional
         Number of mass samples per likelihood evaluation (default: 20)
     N_masses_batch_size : int, optional
@@ -61,7 +61,7 @@ class GWLikelihoodResampled(LikelihoodBase):
         self,
         event_name: str,
         model_dir: str,
-        penalty_value: float = -99999.0,
+        penalty_value: float = 0.0,
         N_masses_evaluation: int = 20,
         N_masses_batch_size: int = 10,
     ) -> None:
@@ -183,7 +183,7 @@ class GWLikelihood(LikelihoodBase):
     model_dir : str
         Path to directory containing the trained normalizing flow model
     penalty_value : float, optional
-        Penalty value for samples where masses exceed Mtov (default: -99999.0)
+        Penalty value for samples where masses exceed Mtov (default: 0.0, i.e. no penalty)
     N_masses_evaluation : int, optional
         Number of mass samples to pre-sample (default: 2000)
         Large values recommended - GPU parallelization makes this cheap!
@@ -248,7 +248,7 @@ class GWLikelihood(LikelihoodBase):
         self,
         event_name: str,
         model_dir: str,
-        penalty_value: float = -99999.0,
+        penalty_value: float = 0.0,
         N_masses_evaluation: int = 2000,
         N_masses_batch_size: int = 1000,
         seed: int = 42,
@@ -346,6 +346,6 @@ class GWLikelihood(LikelihoodBase):
         )
 
         # Take logsumexp over all pre-sampled mass pairs
-        log_likelihood = logsumexp(all_logprobs)
+        log_likelihood = logsumexp(all_logprobs) - jnp.log(self.N_masses_evaluation)
 
         return log_likelihood

--- a/tests/test_inference/test_config.py
+++ b/tests/test_inference/test_config.py
@@ -206,13 +206,12 @@ class TestLikelihoodConfig:
         config = schema.GWLikelihoodConfig(
             enabled=True,
             events=[{"name": "GW170817", "nf_model_dir": "/path/to/data"}],
-            penalty_value=-99999.0,
             N_masses_evaluation=20,
         )
         assert config.type == "gw"
         assert len(config.events) == 1
         assert config.events[0].nf_model_dir == "/path/to/data"
-        assert config.penalty_value == -99999.0
+        assert config.penalty_value == 0.0
 
     def test_gw_likelihood_missing_event_name_fails(self):
         """Test that GW likelihood without event name fails."""


### PR DESCRIPTION
…fault setting

Small tweaks to how the GW likelihood is used. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  - Updated YAML reference documentation for GW likelihood configurations
  - Added guidance for updating likelihood parameter defaults across configurations

* **Updates**
  - GW likelihood penalties now default to no penalty (0.0)
  - Log-likelihood calculations normalized by sample count for improved accuracy
  - Example configurations updated to reflect new defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->