### PR TITLE
Fix concretization type error for spectral expansion constraints

### DIFF
--- a/examples/inference/submit_all.sh
+++ b/examples/inference/submit_all.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Submit all inference jobs found under subdirectories of this script's location.
+# For each submit.sh found, cd into its directory and call sbatch submit.sh.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Searching for submit.sh files under: $SCRIPT_DIR"
+echo ""
+
+submitted=0
+skipped=0
+
+while IFS= read -r submit_script; do
+    job_dir="$(dirname "$submit_script")"
+    rel_dir="${job_dir#"$SCRIPT_DIR/"}"
+
+    echo "Submitting: $rel_dir"
+    if (cd "$job_dir" && sbatch submit.sh); then
+        submitted=$((submitted + 1))
+    else
+        echo "  WARNING: sbatch failed for $rel_dir"
+        skipped=$((skipped + 1))
+    fi
+done < <(find "$SCRIPT_DIR" -mindepth 2 -name "submit.sh" | sort)
+
+echo ""
+echo "Done. Submitted: $submitted, Failed: $skipped"

--- a/jesterTOV/eos/spectral/spectral_decomposition.py
+++ b/jesterTOV/eos/spectral/spectral_decomposition.py
@@ -335,8 +335,9 @@ class SpectralDecomposition_EOS_model(Interpolate_EOS_model):
         gamma_min = jnp.min(gamma_samples)
         gamma_violation = jnp.maximum(0.0, 0.1 - gamma_min)
 
-        # Always construct extra_constraints to avoid Python branching on JAX traced values
-        extra_constraints = {"gamma_bound_violation": float(gamma_violation)}
+        # Always construct extra_constraints to avoid Python branching on JAX traced values.
+        # Do NOT call float() here: gamma_violation is a JAX traced array inside jax.vmap.
+        extra_constraints = {"n_gamma_violations": gamma_violation}
 
         # Generate high-density spectral region
         n_high, p_high, e_high = self._generate_spectral_region(gamma)

--- a/jesterTOV/tov/data_classes.py
+++ b/jesterTOV/tov/data_classes.py
@@ -5,7 +5,7 @@ Uses NamedTuple for immutability and automatic JAX pytree compatibility.
 No additional dependencies required beyond JAX and jaxtyping.
 """
 
-from typing import NamedTuple, Optional
+from typing import Any, NamedTuple, Optional
 from jaxtyping import Float, Array
 
 
@@ -24,10 +24,11 @@ class EOSData(NamedTuple):
     dloge_dlogps: Float[Array, "n_points"]  # d(ln eps)/d(ln p)
     cs2: Float[Array, "n_points"]  # Speed of sound squared
     mu: Optional[Float[Array, "n_points"]] = None  # Chemical potential
-    extra_constraints: Optional[dict[str, float]] = None
-    # EOS-specific constraint violation counts
-    # Convention: Keys use "n_*_violations" or "n_*" format
-    # Examples: {"n_gamma_violations": 5.0} for spectral EOS
+    extra_constraints: Optional[dict[str, Any]] = None
+    # EOS-specific constraint violation magnitudes or counts.
+    # Values must be JAX arrays (not Python float()) when constructed inside jax.vmap.
+    # Convention: Keys use "n_*_violations" or "n_*" format.
+    # Examples: {"n_gamma_violations": jnp.maximum(0.0, 0.1 - gamma_min)} for spectral EOS
 
 
 class TOVSolution(NamedTuple):

--- a/tests/test_inference/test_e2e/conftest.py
+++ b/tests/test_inference/test_e2e/conftest.py
@@ -110,6 +110,19 @@ Z_sym = UniformPrior(-2000.0, 1500.0, parameter_names=["Z_sym"])
 
 
 @pytest.fixture
+def spectral_prior_file(e2e_temp_dir: Path) -> Path:
+    """Create a prior file for spectral decomposition tests."""
+    prior_content = """gamma_0 = UniformPrior(0.2, 2.0, parameter_names=["gamma_0"])
+gamma_1 = UniformPrior(-1.6, 1.7, parameter_names=["gamma_1"])
+gamma_2 = UniformPrior(-0.6, 0.6, parameter_names=["gamma_2"])
+gamma_3 = UniformPrior(-0.02, 0.02, parameter_names=["gamma_3"])
+"""
+    prior_file = e2e_temp_dir / "spectral.prior"
+    prior_file.write_text(prior_content)
+    return prior_file
+
+
+@pytest.fixture
 def chieft_prior_file(e2e_temp_dir: Path) -> Path:
     """Create a prior file with nbreak for chiEFT tests (requires CSE)."""
     prior_content = """E_sat = UniformPrior(-16.1, -15.9, parameter_names=["E_sat"])
@@ -201,6 +214,44 @@ def build_chieft_config(
     }
 
 
+def build_spectral_prior_only_config(
+    sampler_config: dict[str, Any], prior_file: Path, output_dir: Path
+) -> dict[str, Any]:
+    """Build a spectral EOS prior-only config (cheapest spectral test).
+
+    Uses constraints_gamma which is spectral-specific and exercises the
+    n_gamma_violations key written by construct_eos inside jax.vmap.
+    """
+    return {
+        "seed": 42,
+        "dry_run": False,
+        "validate_only": False,
+        "eos": {
+            "type": "spectral",
+            "crust_name": "SLy",
+            "n_points_high": 30,  # 500 -> 30 for speed
+        },
+        "tov": {
+            "type": "gr",
+            "min_nsat_TOV": 0.75,
+            "ndat_TOV": 30,  # 100 -> 30
+            "nb_masses": 20,  # 100 -> 20
+        },
+        "prior": {"specification_file": str(prior_file)},
+        "likelihoods": [
+            {"type": "constraints_eos", "enabled": True},
+            {"type": "constraints_gamma", "enabled": True},
+            {"type": "zero", "enabled": True},
+        ],
+        "sampler": {
+            **sampler_config,
+            "output_dir": str(output_dir),
+            "n_eos_samples": 50,
+        },
+        "postprocessing": {"enabled": False},
+    }
+
+
 # ============================================================================
 # SAMPLER CONFIG FIXTURES
 # ============================================================================
@@ -232,6 +283,39 @@ def smc_rw_chieft_config(chieft_prior_file: Path, e2e_temp_dir: Path) -> dict[st
     """SMC-RW config with chiEFT likelihood."""
     sampler_config = {"type": "smc-rw", **SMC_RW_LIGHTWEIGHT}
     return build_chieft_config(sampler_config, chieft_prior_file, e2e_temp_dir)
+
+
+@pytest.fixture
+def smc_rw_spectral_config(
+    spectral_prior_file: Path, e2e_temp_dir: Path
+) -> dict[str, Any]:
+    """SMC-RW config with spectral EOS and prior-only likelihood."""
+    sampler_config = {"type": "smc-rw", **SMC_RW_LIGHTWEIGHT}
+    return build_spectral_prior_only_config(
+        sampler_config, spectral_prior_file, e2e_temp_dir
+    )
+
+
+@pytest.fixture
+def flowmc_spectral_config(
+    spectral_prior_file: Path, e2e_temp_dir: Path
+) -> dict[str, Any]:
+    """FlowMC config with spectral EOS and prior-only likelihood."""
+    sampler_config = {"type": "flowmc", **FLOWMC_LIGHTWEIGHT}
+    return build_spectral_prior_only_config(
+        sampler_config, spectral_prior_file, e2e_temp_dir
+    )
+
+
+@pytest.fixture
+def blackjax_ns_aw_spectral_config(
+    spectral_prior_file: Path, e2e_temp_dir: Path
+) -> dict[str, Any]:
+    """BlackJAX NS-AW config with spectral EOS and prior-only likelihood."""
+    sampler_config = {"type": "blackjax-ns-aw", **BLACKJAX_NS_AW_LIGHTWEIGHT}
+    return build_spectral_prior_only_config(
+        sampler_config, spectral_prior_file, e2e_temp_dir
+    )
 
 
 @pytest.fixture

--- a/tests/test_inference/test_e2e/test_e2e_prior_only.py
+++ b/tests/test_inference/test_e2e/test_e2e_prior_only.py
@@ -139,6 +139,116 @@ class TestPriorOnlyFast:
 
 @pytest.mark.integration
 @pytest.mark.e2e
+class TestSpectralPriorOnly:
+    """Prior-only tests for the spectral EOS - regression tests for JAX vmap compatibility.
+
+    These tests specifically guard against ConcretizationTypeError caused by
+    calling Python float() on a JAX traced array inside construct_eos, which
+    only manifests when the transform is invoked via jax.vmap (as in sampling).
+
+    All samplers are covered because the vmap happens inside the sampler's
+    log_prob function, regardless of sampler type.
+    """
+
+    SPECTRAL_PARAMS = ["gamma_0", "gamma_1", "gamma_2", "gamma_3"]
+
+    def test_smc_rw_spectral_prior_only(self, smc_rw_spectral_config, e2e_temp_dir):
+        """Regression test: spectral EOS must not crash under SMC-RW sampling."""
+        smc_rw_spectral_config["sampler"]["n_particles"] = 50
+        smc_rw_spectral_config["sampler"]["n_mcmc_steps"] = 2
+
+        config = InferenceConfig(**smc_rw_spectral_config)
+
+        prior = setup_prior(config)
+        keep_names = determine_keep_names(config, prior)
+        transform = setup_transform(config, prior=prior, keep_names=keep_names)
+        likelihood = setup_likelihood(config, transform)
+
+        sampler = create_sampler(
+            config=config.sampler,
+            prior=prior,
+            likelihood=likelihood,
+            likelihood_transforms=[transform],
+            seed=config.seed,
+        )
+
+        key = jax.random.PRNGKey(config.seed)
+        sampler.sample(key)
+
+        output = sampler.get_sampler_output()
+
+        for param in self.SPECTRAL_PARAMS:
+            assert param in output.samples
+        assert not jnp.isnan(output.log_prob).any()
+
+    def test_flowmc_spectral_prior_only(self, flowmc_spectral_config, e2e_temp_dir):
+        """Regression test: spectral EOS must not crash under FlowMC sampling."""
+        flowmc_spectral_config["sampler"]["n_chains"] = 20
+        flowmc_spectral_config["sampler"]["n_loop_training"] = 2
+        flowmc_spectral_config["sampler"]["n_loop_production"] = 2
+        flowmc_spectral_config["sampler"]["n_local_steps"] = 5
+        flowmc_spectral_config["sampler"]["n_global_steps"] = 5
+
+        config = InferenceConfig(**flowmc_spectral_config)
+
+        prior = setup_prior(config)
+        keep_names = determine_keep_names(config, prior)
+        transform = setup_transform(config, prior=prior, keep_names=keep_names)
+        likelihood = setup_likelihood(config, transform)
+
+        sampler = create_sampler(
+            config=config.sampler,
+            prior=prior,
+            likelihood=likelihood,
+            likelihood_transforms=[transform],
+            seed=config.seed,
+        )
+
+        key = jax.random.PRNGKey(config.seed)
+        sampler.sample(key)
+
+        output = sampler.get_sampler_output()
+
+        for param in self.SPECTRAL_PARAMS:
+            assert param in output.samples
+        assert not jnp.isnan(output.log_prob).any()
+
+    def test_blackjax_ns_aw_spectral_prior_only(
+        self, blackjax_ns_aw_spectral_config, e2e_temp_dir
+    ):
+        """Regression test: spectral EOS must not crash under NS-AW sampling."""
+        blackjax_ns_aw_spectral_config["sampler"]["n_live"] = 50
+        blackjax_ns_aw_spectral_config["sampler"]["n_target"] = 10
+        blackjax_ns_aw_spectral_config["sampler"]["max_mcmc"] = 200
+        blackjax_ns_aw_spectral_config["sampler"]["termination_dlogz"] = 1.0
+
+        config = InferenceConfig(**blackjax_ns_aw_spectral_config)
+
+        prior = setup_prior(config)
+        keep_names = determine_keep_names(config, prior)
+        transform = setup_transform(config, prior=prior, keep_names=keep_names)
+        likelihood = setup_likelihood(config, transform)
+
+        sampler = create_sampler(
+            config=config.sampler,
+            prior=prior,
+            likelihood=likelihood,
+            likelihood_transforms=[transform],
+            seed=config.seed,
+        )
+
+        key = jax.random.PRNGKey(config.seed)
+        sampler.sample(key)
+
+        output = sampler.get_sampler_output()
+
+        for param in self.SPECTRAL_PARAMS:
+            assert param in output.samples
+        assert not jnp.isnan(output.log_prob).any()
+
+
+@pytest.mark.integration
+@pytest.mark.e2e
 class TestSamplerFactorySmoke:
     """Smoke tests for sampler factory - verify all samplers can be instantiated."""
 

--- a/tests/test_inference/test_transforms.py
+++ b/tests/test_inference/test_transforms.py
@@ -1,6 +1,7 @@
 """Tests for unified JesterTransform system."""
 
 import pytest
+import jax
 import jax.numpy as jnp
 
 from jesterTOV.inference.config.schema import (
@@ -287,3 +288,72 @@ class TestJesterTransformIntegration:
         for param, value in realistic_nep_stiff.items():
             assert param in result
             assert result[param] == value
+
+
+# Realistic spectral params (LALSuite-compatible, within standard prior bounds)
+SPECTRAL_PARAMS = {
+    "gamma_0": 1.35,
+    "gamma_1": 0.5,
+    "gamma_2": 0.1,
+    "gamma_3": 0.005,
+}
+
+
+class TestSpectralTransform:
+    """Tests specific to the spectral decomposition transform."""
+
+    @pytest.mark.slow
+    def test_spectral_forward_single(self):
+        """Test single forward pass of spectral transform."""
+        eos_config = SpectralEOSConfig(type="spectral", crust_name="SLy")
+        tov_config = TOVConfig(ndat_TOV=30)
+        transform = JesterTransform.from_config(eos_config, tov_config)
+
+        result = transform.forward(SPECTRAL_PARAMS)
+
+        assert "masses_EOS" in result
+        assert "radii_EOS" in result
+        assert "Lambdas_EOS" in result
+        assert jnp.isfinite(result["masses_EOS"]).any()
+
+    @pytest.mark.slow
+    def test_spectral_forward_vmap(self):
+        """Regression test: spectral forward must not crash under jax.vmap.
+
+        The bug was that construct_eos called float(gamma_violation) on a JAX
+        traced array, which raises ConcretizationTypeError inside vmap.
+        """
+        eos_config = SpectralEOSConfig(type="spectral", crust_name="SLy")
+        tov_config = TOVConfig(ndat_TOV=30)
+        transform = JesterTransform.from_config(eos_config, tov_config)
+
+        # Batch of 3 spectral parameter sets
+        params_batch = {
+            "gamma_0": jnp.array([1.35, 1.5, 0.8]),
+            "gamma_1": jnp.array([0.5, 0.2, 0.3]),
+            "gamma_2": jnp.array([0.1, 0.05, 0.0]),
+            "gamma_3": jnp.array([0.005, 0.001, -0.001]),
+        }
+
+        # This must not raise jax.errors.ConcretizationTypeError
+        results = jax.vmap(transform.forward)(params_batch)
+
+        assert "masses_EOS" in results
+        assert results["masses_EOS"].shape[0] == 3
+
+    @pytest.mark.slow
+    def test_spectral_gamma_constraint_key_present(self):
+        """Test that spectral EOS populates n_gamma_violations in transform output.
+
+        This key is consumed by ConstraintGammaLikelihood.
+        """
+        eos_config = SpectralEOSConfig(type="spectral", crust_name="SLy")
+        tov_config = TOVConfig(ndat_TOV=30)
+        transform = JesterTransform.from_config(eos_config, tov_config)
+
+        result = transform.forward(SPECTRAL_PARAMS)
+
+        assert "n_gamma_violations" in result, (
+            "Spectral transform must include 'n_gamma_violations' for "
+            "ConstraintGammaLikelihood to work correctly"
+        )


### PR DESCRIPTION
The constraints_eos had a bug which caused an error when running spectral EOSs due to a float call inside a vmap. This removes the float and also adds extra tests that should catch similar behavior in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated batch job submission script for inference workflows.

* **Tests**
  * Expanded test coverage for spectral equation of state configurations across multiple inference samplers.
  * Added validation tests for spectral parameter transforms and constraint tracking.

* **Chores**
  * Enhanced internal constraint representation in equation of state computations for improved compatibility with vectorized operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->