### PR TITLE
Add random key to prior only for NICER KDE

### DIFF
--- a/jesterTOV/inference/run_inference.py
+++ b/jesterTOV/inference/run_inference.py
@@ -105,7 +105,8 @@ def setup_prior(config: InferenceConfig) -> CombinePrior:
     nb_CSE = config.eos.nb_CSE if isinstance(config.eos, MetamodelCSEEOSConfig) else 0
 
     # Check if GW or NICER likelihoods are enabled (both need _random_key)
-    # Note: gw_presampled does NOT need _random_key (uses fixed seed at init)
+    # Note: the default `gw` and `nicer` likelihoods do NOT need
+    # _random_key as they pre-generate masses on which to evaluate
     needs_random_key = False
     for lk in config.likelihoods:
         if lk.enabled and lk.type in ["gw_resampled", "nicer_kde"]:


### PR DESCRIPTION
We add a random key that is sampled on-the-fly for some likelihoods, such as the (older, now deprecated) NICER likelihoods with KDE which sampled the NICER masses on-the-fly. With #69 , this was not changed so the random key is now added for the new likelihood, which should not happen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of random key initialization during inference for certain likelihood configurations, ensuring correct behavior for specific analysis types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->