### PR TITLE
Install instructions from git not PyPI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -480,6 +480,7 @@ uv build
 git tag v0.x.x
 git push origin v0.x.x
 
-# 6. Publish to PyPI
-uv publish --token <token>
+# 6. PyPI publishing is NOT possible - jester depends on a specific fork of blackjax
+# (https://github.com/handley-lab/blackjax) which cannot be published to PyPI.
+# Users install directly from the GitHub repository via git clone.
 ```

--- a/README.md
+++ b/README.md
@@ -23,17 +23,8 @@ Moreover, the following samplers are supported:
 
 ## Installation
 
-The latest stable release version can be installed with `pip`:
-```bash
-pip install jesterTOV
-```
+`jester` depends on a [specific fork of blackjax](https://github.com/handley-lab/blackjax) for nested sampling support, which prevents publishing to PyPI. Install the latest version by cloning the repository:
 
-To run Bayesian inference, make sure to install support for CUDA or upgrade `jax` according to [the `jax` documentation page](https://docs.jax.dev/en/latest/installation.html):
-```bash
-pip install "jax[cuda12]"
-```
-
-For developers, we recommend installing locally with `uv`:
 ```bash
 git clone https://github.com/nuclear-multimessenger-astronomy/jester
 cd jester
@@ -44,7 +35,12 @@ Extra dependencies can be installed as follows:
 ```bash
 uv sync --extra cuda12 # For GPU support (fast sampling)
 uv sync --extra docs   # To work on documentation locally
-uv sync --extra dev    # To run tests locally 
+uv sync --extra dev    # To run tests locally
+```
+
+To run Bayesian inference, make sure to install support for CUDA or upgrade `jax` according to [the `jax` documentation page](https://docs.jax.dev/en/latest/installation.html):
+```bash
+uv sync --extra cuda12
 ```
 
 ## Examples

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,16 +55,8 @@ See the :doc:`overview` guide for detailed explanations.
 Installation
 =============
 
-The latest stable release version can be installed with ``pip``::
-
-    pip install jesterTOV
-
-To run Bayesian inference, make sure to install support for CUDA or upgrade ``jax`` according to the
-`jax documentation page <https://docs.jax.dev/en/latest/installation.html>`_::
-
-    pip install "jax[cuda12]"
-
-For developers, we recommend installing locally with ``uv``::
+``jester`` depends on a `specific fork of blackjax <https://github.com/handley-lab/blackjax>`_ for nested sampling support,
+which prevents publishing to PyPI. Install the latest version by cloning the repository::
 
     git clone https://github.com/nuclear-multimessenger-astronomy/jester
     cd jester
@@ -74,6 +66,11 @@ Extra dependencies can be installed as follows::
 
     uv sync --extra cuda12   # For GPU support (fast sampling)
     uv sync --extra dev      # For developers (work on documentation, run tests,...)
+
+To run Bayesian inference, make sure to install support for CUDA or upgrade ``jax`` according to the
+`jax documentation page <https://docs.jax.dev/en/latest/installation.html>`_::
+
+    uv sync --extra cuda12
 
 
 Contents

--- a/uv.lock
+++ b/uv.lock
@@ -297,6 +297,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/c5/ad5ca082b2610defc488679690df8137300c6bb396b24f783e3d74873fa4/bilby.cython-0.5.3-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:264ccd8ca1adabc794931ed6deb5082ad0ed4b52694be8158cb421a80a752bca", size = 351851, upload-time = "2024-08-23T15:22:07.895Z" },
     { url = "https://files.pythonhosted.org/packages/13/26/f0b46d56d278665b484ec421dc571fb28bdd81635137d00e0edc2c8fddc9/bilby.cython-0.5.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:44e5e381c2861e26a4e1fd5c591ea0c3c9a0e2f0d8c78f28f8704abf2945cd8d", size = 1014120, upload-time = "2024-08-23T15:22:09.942Z" },
     { url = "https://files.pythonhosted.org/packages/11/de/02429d598ec5ed4c70113a2c3e8b76a5b113885f85eacdcdaf19cbb6d23d/bilby.cython-0.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:2758256339d7c3703014b265d3a77e0299d5c6264f962bc311c989ac453cbd60", size = 357801, upload-time = "2024-08-23T15:54:20.941Z" },
+    { url = "https://files.pythonhosted.org/packages/73/b9/e8a78c082d8708ea4cc9c65b53dfed9d1d6bc9b3a44d712811b9e55022ee/bilby_cython-0.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:d39ad43c8962a32b7c561ee07f0f9fb9e656a7847b30176695007b31426d2474", size = 363731, upload-time = "2026-02-23T16:52:49.722Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a2/6a8e2a8a0721b758745e2a35f91c5ff380cf0f795408bc74b9aa8c589f0a/bilby_cython-0.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:9aabbcce359c63c78cf1c1bf4d714c438a2936ddd4e061fe90b3320415dd12f6", size = 361366, upload-time = "2026-02-23T16:52:50.964Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/6d/4941b4a82e118eb2b1c10ae0794e96b3424d33b688e65e20d914216d62a9/bilby_cython-0.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:e5353bd484052af682b4ed70439266f56ca59d8feb5f2a613f68e3675bce8c04", size = 360744, upload-time = "2026-02-23T16:52:52.185Z" },
 ]
 
 [[package]]
@@ -1377,7 +1380,7 @@ wheels = [
 
 [[package]]
 name = "jestertov"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anesthetic" },


### PR DESCRIPTION
The dependency on the specific blackjax fork means we cannot publish to PyPI, so tell users to install from the git source instead. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to use git clone and uv sync instead of pip
  * Updated release documentation noting PyPI publishing is unavailable due to project dependencies
  * Reorganized installation guidance with new CUDA/JAX support setup flow
  * Updated developer setup workflow to reflect repository-based installation method

<!-- end of auto-generated comment: release notes by coderabbit.ai -->