### PR TITLE
Scalar-Tensor theory update draft PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,4 +164,3 @@ cython_debug/
 lalsuite/
 
 examples/inference/*/*/outdir/
-cython_debug/

--- a/jesterTOV/inference/transforms/transform.py
+++ b/jesterTOV/inference/transforms/transform.py
@@ -287,11 +287,6 @@ class JesterTransform(NtoMTransform):
         elif isinstance(config, ScalarTensorTOVConfig):
             from jesterTOV.tov.scalar_tensor import ScalarTensorTOVSolver
             return ScalarTensorTOVSolver()
-
-        # String-based dispatch for solvers that do not yet have their own config class
-        tov_type = config.type
-        if tov_type == "post":
-            raise NotImplementedError("PostTOVSolver config class not implemented yet")
         elif isinstance(config, AnisotropyTOVConfig):
             from jesterTOV.tov.anisotropy import AnisotropyTOVSolver
             return AnisotropyTOVSolver()

--- a/jesterTOV/tov/base.py
+++ b/jesterTOV/tov/base.py
@@ -221,7 +221,7 @@ class TOVSolverBase(ABC):
         pcs_lim, masses_lim, radii_lim, lambdas_lim = utils.limit_by_MTOV_and_interpolate(
             pcs, masses_solar, radii_km, lambdas, ndat
         )
-
+        # @TODO: merge extras interpolation in a single call in above.
         # Process extra solver-specific fields if provided
         extra_processed: Optional[dict[str, Float[Array, "ndat"]]] = None
         if extra is not None:


### PR DESCRIPTION
- Improving efficiency of ST calculation
- Adding extra quantities from TOV solvers (e.g, scalar-mode tidal deformabilities, charge, etc) as a dictionary.
- Integrating ST inference with new Jester inference schema
- Updating example file `docs/examples/eos_tov/EoS_beyondGR.ipynb`
- Adding EoS validity check (e.g., negative enthalpy or speed of sound limits) and convert it to `nan` to ensure physically invalid EoS not passed into solver and introduce bias. Moved from TOV solver to ensure these filters done before `vmap` operation.
- Changing MTOV limit and interpolation approach to remove unstable region between curves while maintaining number of points (`ndat`) for each M-R-Lambda curve.
- Adding standalone interpolation method so it not depends on `interpax`.
- Other minor fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Scalar-Tensor TOV solver for modeling scalar-tensor gravity theories.
  * Enhanced TOV solvers to report additional tidal deformability quantities.
  * New inference example workflow for Scalar-Tensor Random Walk sampling.

* **Documentation**
  * Updated example notebooks with new TOV parameter configuration API.

* **Chores**
  * Improved interpolation and MTOV handling utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->