### PR TITLE
Integrate MM+peakCSE in the inference workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ This file provides guidance to Claude Code when working with the JESTER reposito
 
 ## IMPORTANT GUIDELINES
 
+**Contributing guide**: `CONTRIBUTING.md` at the repo root is the authoritative reference for development workflow, PR requirements, and how to add new EOS models, TOV solvers, and likelihoods. Always consult it when working on new features or before opening a PR.
+
 **Testing Philosophy**: When tests fail, investigate root causes rather than modifying tests to pass.
 
 **Examples**: In the examples, you will sometimes find `submit.sh` files for submitting the tests on a cluster. These might have hardcoded paths etc, but ignore those: these files are just intended as an example and they should not be judged so rigourously as the source code.
@@ -13,6 +15,8 @@ This file provides guidance to Claude Code when working with the JESTER reposito
 **Documentation Style**: Write clear, concise documentation in full sentences as if by a human researcher. Avoid LLM-like verbosity.
 
 **Documentation Maintenance**: When making changes to source code (adding/removing/renaming classes, functions, or modules), check if API reference documentation needs updating. Module overview pages in `docs/api/` should list all public classes/functions. See `docs/CLAUDE.md` for detailed documentation guidelines. In case a major refactoring is done, changing the layout of the repo, then we have to check the API references automatic docs building is up to date.
+
+**Sphinx warnings are errors**: CI runs `sphinx-build -W --keep-going`, which turns every Sphinx warning into a build failure that blocks merging. After any documentation or docstring change, always verify locally with `uv run sphinx-build -W --keep-going docs docs/_build/html` before committing. Common pitfalls: unexpected indentation in docstrings (e.g. a `:` followed by a more-indented line), inline bracket-wrapped lists in return descriptions, and missing or malformed cross-references.
 
 **Math Formatting in Docstrings**: All mathematical expressions in docstrings must use Sphinx/reStructuredText formatting for proper rendering in documentation:
 - Use `:math:` role for inline math: `:math:`\Gamma(x)`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,12 +45,14 @@ uv run pre-commit run --all-files
 # Build docs locally
 uv run sphinx-build docs docs/_build/html
 
-# Build in strict mode (same as CI)
+# Build in strict mode (same as CI) — ALWAYS run this before opening a PR
 uv run sphinx-build -W --keep-going docs docs/_build/html
 
 # Open in browser
 open docs/_build/html/index.html  # macOS
 ```
+
+> **Sphinx warnings are treated as errors in CI.** The `-W` flag used by the CI pipeline turns every Sphinx warning (undefined references, unexpected indentation, missing docstrings, etc.) into a hard build failure. A PR cannot be merged if the docs build fails. Always run the strict-mode build locally before pushing to catch issues early — it is much faster to fix a warning locally than to iterate on CI.
 
 > **Note — `.. plot::` directive caching:** Sphinx caches the output of `.. plot::` directives
 > and only regenerates them when the **Python script file** changes, not when any data files
@@ -218,7 +220,7 @@ For new EOS/TOV/Likelihood features:
 ### What Reviewers (and CI/CD pipeline) Look For
 
 - All tests pass (including type checking)
-- Documentation builds without warnings
+- **Documentation builds without warnings** — Sphinx runs with `-W` in CI so any warning blocks the merge. Run `uv run sphinx-build -W --keep-going docs docs/_build/html` locally before pushing.
 - Code follows project conventions (see `CLAUDE.md`)
 - Comprehensive tests covering edge cases
 - Clear commit messages

--- a/examples/inference/mm_peakcse/GW170817/config.yaml
+++ b/examples/inference/mm_peakcse/GW170817/config.yaml
@@ -1,0 +1,48 @@
+seed: 43
+dry_run: false
+validate_only: false
+eos:
+  type: metamodel_peak_cse
+  ndat_metamodel: 100
+  nmax_nsat: 25.0
+  ndat_CSE: 100
+  crust_name: DH
+tov:
+  min_nsat_TOV: 0.75
+  ndat_TOV: 100
+  nb_masses: 100
+  type: gr
+prior:
+  specification_file: prior.prior
+likelihoods:
+- type: constraints_eos
+  enabled: true
+- type: gw
+  enabled: true
+  events:
+  - name: GW170817
+  N_masses_evaluation: 2000
+  N_masses_batch_size: 1000
+  seed: 42
+- type: radio
+  enabled: true
+  pulsars:
+  - name: J1614
+    mass_mean: 1.94
+    mass_std: 0.06
+  - name: J0740
+    mass_mean: 2.08
+    mass_std: 0.14
+sampler:
+  type: smc-rw
+  n_particles: 5000
+  n_mcmc_steps: 10
+  target_ess: 0.9
+  random_walk_sigma: 0.05
+  n_eos_samples: 5000
+  output_dir: ./outdir/
+postprocessing:
+  enabled: true
+  make_cornerplot: true
+  make_massradius: true
+  make_pressuredensity: true

--- a/examples/inference/mm_peakcse/GW170817/prior.prior
+++ b/examples/inference/mm_peakcse/GW170817/prior.prior
@@ -1,0 +1,25 @@
+# Nuclear Empirical Parameters (NEPs) - same as metamodel_cse
+E_sat = UniformPrior(-16.1, -15.9, parameter_names=["E_sat"])
+K_sat = UniformPrior(150.0, 300.0, parameter_names=["K_sat"])
+Q_sat = UniformPrior(-500.0, 1100.0, parameter_names=["Q_sat"])
+Z_sat = UniformPrior(-2500.0, 1500.0, parameter_names=["Z_sat"])
+E_sym = UniformPrior(28.0, 45.0, parameter_names=["E_sym"])
+L_sym = UniformPrior(10.0, 200.0, parameter_names=["L_sym"])
+K_sym = UniformPrior(-400.0, 200.0, parameter_names=["K_sym"])
+Q_sym = UniformPrior(-1000.0, 1500.0, parameter_names=["Q_sym"])
+Z_sym = UniformPrior(-2000.0, 1500.0, parameter_names=["Z_sym"])
+
+# Break density between meta-model and peakCSE regions [fm^-3]
+nbreak = UniformPrior(0.16, 0.32, parameter_names=["nbreak"])
+
+# peakCSE parameters - priors from arXiv:2507.13039 (Tab. astro_prior)
+# Gaussian peak amplitude c^2_{s,peak}
+gaussian_peak = UniformPrior(0.1, 1.0, parameter_names=["gaussian_peak"])
+# Gaussian peak center n_peak [fm^-3]
+gaussian_mu = UniformPrior(0.32, 1.92, parameter_names=["gaussian_mu"])
+# Gaussian peak width sigma_peak [fm^-3]
+gaussian_sigma = UniformPrior(0.016, 0.8, parameter_names=["gaussian_sigma"])
+# Logistic growth rate l_sig [fm^3]
+logit_growth_rate = UniformPrior(0.1, 1.0, parameter_names=["logit_growth_rate"])
+# Logistic midpoint n_sig [fm^-3]
+logit_midpoint = UniformPrior(0.32, 5.6, parameter_names=["logit_midpoint"])

--- a/examples/inference/mm_peakcse/NICER_J0030/config.yaml
+++ b/examples/inference/mm_peakcse/NICER_J0030/config.yaml
@@ -1,0 +1,40 @@
+seed: 44
+dry_run: false
+validate_only: false
+eos:
+  type: metamodel_peak_cse
+  ndat_metamodel: 100
+  nmax_nsat: 25.0
+  ndat_CSE: 100
+  crust_name: DH
+tov:
+  min_nsat_TOV: 0.75
+  ndat_TOV: 100
+  nb_masses: 100
+  type: gr
+prior:
+  specification_file: prior.prior
+likelihoods:
+- type: constraints_eos
+  enabled: true
+- type: nicer
+  enabled: true
+  pulsars:
+  - name: J0030
+    amsterdam_model_dir: ../../../../jesterTOV/inference/flows/models/nicer_maf/J00300451/amsterdam_st_pst
+    maryland_model_dir: ../../../../jesterTOV/inference/flows/models/nicer_maf/J00300451/maryland_2spot_rm
+  N_masses_evaluation: 20
+  N_masses_batch_size: 20
+sampler:
+  type: smc-rw
+  n_particles: 5000
+  n_mcmc_steps: 10
+  target_ess: 0.9
+  random_walk_sigma: 0.05
+  n_eos_samples: 5000
+  output_dir: ./outdir/
+postprocessing:
+  enabled: true
+  make_cornerplot: false
+  make_massradius: true
+  make_pressuredensity: true

--- a/examples/inference/mm_peakcse/NICER_J0030/prior.prior
+++ b/examples/inference/mm_peakcse/NICER_J0030/prior.prior
@@ -1,0 +1,25 @@
+# Nuclear Empirical Parameters (NEPs) - same as metamodel_cse
+E_sat = UniformPrior(-16.1, -15.9, parameter_names=["E_sat"])
+K_sat = UniformPrior(150.0, 300.0, parameter_names=["K_sat"])
+Q_sat = UniformPrior(-500.0, 1100.0, parameter_names=["Q_sat"])
+Z_sat = UniformPrior(-2500.0, 1500.0, parameter_names=["Z_sat"])
+E_sym = UniformPrior(28.0, 45.0, parameter_names=["E_sym"])
+L_sym = UniformPrior(10.0, 200.0, parameter_names=["L_sym"])
+K_sym = UniformPrior(-400.0, 200.0, parameter_names=["K_sym"])
+Q_sym = UniformPrior(-1000.0, 1500.0, parameter_names=["Q_sym"])
+Z_sym = UniformPrior(-2000.0, 1500.0, parameter_names=["Z_sym"])
+
+# Break density between meta-model and peakCSE regions [fm^-3]
+nbreak = UniformPrior(0.16, 0.32, parameter_names=["nbreak"])
+
+# peakCSE parameters - priors from arXiv:2507.13039 (Tab. astro_prior)
+# Gaussian peak amplitude c^2_{s,peak}
+gaussian_peak = UniformPrior(0.1, 1.0, parameter_names=["gaussian_peak"])
+# Gaussian peak center n_peak [fm^-3]
+gaussian_mu = UniformPrior(0.32, 1.92, parameter_names=["gaussian_mu"])
+# Gaussian peak width sigma_peak [fm^-3]
+gaussian_sigma = UniformPrior(0.016, 0.8, parameter_names=["gaussian_sigma"])
+# Logistic growth rate l_sig [fm^3]
+logit_growth_rate = UniformPrior(0.1, 1.0, parameter_names=["logit_growth_rate"])
+# Logistic midpoint n_sig [fm^-3]
+logit_midpoint = UniformPrior(0.32, 5.6, parameter_names=["logit_midpoint"])

--- a/examples/inference/mm_peakcse/NICER_J0437/config.yaml
+++ b/examples/inference/mm_peakcse/NICER_J0437/config.yaml
@@ -1,0 +1,39 @@
+seed: 44
+dry_run: false
+validate_only: false
+eos:
+  type: metamodel_peak_cse
+  ndat_metamodel: 100
+  nmax_nsat: 25.0
+  ndat_CSE: 100
+  crust_name: DH
+tov:
+  min_nsat_TOV: 0.75
+  ndat_TOV: 100
+  nb_masses: 100
+  type: gr
+prior:
+  specification_file: prior.prior
+likelihoods:
+- type: constraints_eos
+  enabled: true
+- type: nicer
+  enabled: true
+  pulsars:
+  - name: J0437
+    amsterdam_model_dir: ../../../../jesterTOV/inference/flows/models/nicer_maf/J04374715/amsterdam_cst_pdt
+  N_masses_evaluation: 20
+  N_masses_batch_size: 20
+sampler:
+  type: smc-rw
+  n_particles: 5000
+  n_mcmc_steps: 10
+  target_ess: 0.9
+  random_walk_sigma: 0.05
+  n_eos_samples: 5000
+  output_dir: ./outdir/
+postprocessing:
+  enabled: true
+  make_cornerplot: false
+  make_massradius: true
+  make_pressuredensity: true

--- a/examples/inference/mm_peakcse/NICER_J0437/prior.prior
+++ b/examples/inference/mm_peakcse/NICER_J0437/prior.prior
@@ -1,0 +1,25 @@
+# Nuclear Empirical Parameters (NEPs) - same as metamodel_cse
+E_sat = UniformPrior(-16.1, -15.9, parameter_names=["E_sat"])
+K_sat = UniformPrior(150.0, 300.0, parameter_names=["K_sat"])
+Q_sat = UniformPrior(-500.0, 1100.0, parameter_names=["Q_sat"])
+Z_sat = UniformPrior(-2500.0, 1500.0, parameter_names=["Z_sat"])
+E_sym = UniformPrior(28.0, 45.0, parameter_names=["E_sym"])
+L_sym = UniformPrior(10.0, 200.0, parameter_names=["L_sym"])
+K_sym = UniformPrior(-400.0, 200.0, parameter_names=["K_sym"])
+Q_sym = UniformPrior(-1000.0, 1500.0, parameter_names=["Q_sym"])
+Z_sym = UniformPrior(-2000.0, 1500.0, parameter_names=["Z_sym"])
+
+# Break density between meta-model and peakCSE regions [fm^-3]
+nbreak = UniformPrior(0.16, 0.32, parameter_names=["nbreak"])
+
+# peakCSE parameters - priors from arXiv:2507.13039 (Tab. astro_prior)
+# Gaussian peak amplitude c^2_{s,peak}
+gaussian_peak = UniformPrior(0.1, 1.0, parameter_names=["gaussian_peak"])
+# Gaussian peak center n_peak [fm^-3]
+gaussian_mu = UniformPrior(0.32, 1.92, parameter_names=["gaussian_mu"])
+# Gaussian peak width sigma_peak [fm^-3]
+gaussian_sigma = UniformPrior(0.016, 0.8, parameter_names=["gaussian_sigma"])
+# Logistic growth rate l_sig [fm^3]
+logit_growth_rate = UniformPrior(0.1, 1.0, parameter_names=["logit_growth_rate"])
+# Logistic midpoint n_sig [fm^-3]
+logit_midpoint = UniformPrior(0.32, 5.6, parameter_names=["logit_midpoint"])

--- a/examples/inference/mm_peakcse/NICER_J0614/config.yaml
+++ b/examples/inference/mm_peakcse/NICER_J0614/config.yaml
@@ -1,0 +1,39 @@
+seed: 44
+dry_run: false
+validate_only: false
+eos:
+  type: metamodel_peak_cse
+  ndat_metamodel: 100
+  nmax_nsat: 25.0
+  ndat_CSE: 100
+  crust_name: DH
+tov:
+  min_nsat_TOV: 0.75
+  ndat_TOV: 100
+  nb_masses: 100
+  type: gr
+prior:
+  specification_file: prior.prior
+likelihoods:
+- type: constraints_eos
+  enabled: true
+- type: nicer
+  enabled: true
+  pulsars:
+  - name: J0614
+    amsterdam_model_dir: ../../../../jesterTOV/inference/flows/models/nicer_maf/J06143329/amsterdam_st_pdt
+  N_masses_evaluation: 20
+  N_masses_batch_size: 20
+sampler:
+  type: smc-rw
+  n_particles: 5000
+  n_mcmc_steps: 10
+  target_ess: 0.9
+  random_walk_sigma: 0.05
+  n_eos_samples: 5000
+  output_dir: ./outdir/
+postprocessing:
+  enabled: true
+  make_cornerplot: false
+  make_massradius: true
+  make_pressuredensity: true

--- a/examples/inference/mm_peakcse/NICER_J0614/prior.prior
+++ b/examples/inference/mm_peakcse/NICER_J0614/prior.prior
@@ -1,0 +1,25 @@
+# Nuclear Empirical Parameters (NEPs) - same as metamodel_cse
+E_sat = UniformPrior(-16.1, -15.9, parameter_names=["E_sat"])
+K_sat = UniformPrior(150.0, 300.0, parameter_names=["K_sat"])
+Q_sat = UniformPrior(-500.0, 1100.0, parameter_names=["Q_sat"])
+Z_sat = UniformPrior(-2500.0, 1500.0, parameter_names=["Z_sat"])
+E_sym = UniformPrior(28.0, 45.0, parameter_names=["E_sym"])
+L_sym = UniformPrior(10.0, 200.0, parameter_names=["L_sym"])
+K_sym = UniformPrior(-400.0, 200.0, parameter_names=["K_sym"])
+Q_sym = UniformPrior(-1000.0, 1500.0, parameter_names=["Q_sym"])
+Z_sym = UniformPrior(-2000.0, 1500.0, parameter_names=["Z_sym"])
+
+# Break density between meta-model and peakCSE regions [fm^-3]
+nbreak = UniformPrior(0.16, 0.32, parameter_names=["nbreak"])
+
+# peakCSE parameters - priors from arXiv:2507.13039 (Tab. astro_prior)
+# Gaussian peak amplitude c^2_{s,peak}
+gaussian_peak = UniformPrior(0.1, 1.0, parameter_names=["gaussian_peak"])
+# Gaussian peak center n_peak [fm^-3]
+gaussian_mu = UniformPrior(0.32, 1.92, parameter_names=["gaussian_mu"])
+# Gaussian peak width sigma_peak [fm^-3]
+gaussian_sigma = UniformPrior(0.016, 0.8, parameter_names=["gaussian_sigma"])
+# Logistic growth rate l_sig [fm^3]
+logit_growth_rate = UniformPrior(0.1, 1.0, parameter_names=["logit_growth_rate"])
+# Logistic midpoint n_sig [fm^-3]
+logit_midpoint = UniformPrior(0.32, 5.6, parameter_names=["logit_midpoint"])

--- a/examples/inference/mm_peakcse/NICER_J0740/config.yaml
+++ b/examples/inference/mm_peakcse/NICER_J0740/config.yaml
@@ -1,0 +1,49 @@
+seed: 42
+dry_run: false
+validate_only: false
+eos:
+  type: metamodel_peak_cse
+  ndat_metamodel: 100
+  nmax_nsat: 25.0
+  ndat_CSE: 100
+  crust_name: DH
+tov:
+  min_nsat_TOV: 0.75
+  ndat_TOV: 100
+  nb_masses: 100
+  type: gr
+prior:
+  specification_file: prior.prior
+likelihoods:
+- type: constraints_eos
+  enabled: true
+- type: radio
+  enabled: true
+  pulsars:
+  - name: J1614
+    mass_mean: 1.94
+    mass_std: 0.06
+  - name: J0740
+    mass_mean: 2.08
+    mass_std: 0.14
+- type: nicer
+  enabled: true
+  pulsars:
+  - name: J0740
+    amsterdam_model_dir: ../../../../jesterTOV/inference/flows/models/nicer_maf/J07406620/amsterdam_gamma_nicerxmm
+    maryland_model_dir: ../../../../jesterTOV/inference/flows/models/nicer_maf/J07406620/maryland_unknown_nicerxmm_rm
+  N_masses_evaluation: 20
+  N_masses_batch_size: 20
+sampler:
+  type: smc-rw
+  n_particles: 5000
+  n_mcmc_steps: 10
+  target_ess: 0.9
+  random_walk_sigma: 0.05
+  n_eos_samples: 5000
+  output_dir: ./outdir/
+postprocessing:
+  enabled: true
+  make_cornerplot: false
+  make_massradius: true
+  make_pressuredensity: true

--- a/examples/inference/mm_peakcse/NICER_J0740/prior.prior
+++ b/examples/inference/mm_peakcse/NICER_J0740/prior.prior
@@ -1,0 +1,25 @@
+# Nuclear Empirical Parameters (NEPs) - same as metamodel_cse
+E_sat = UniformPrior(-16.1, -15.9, parameter_names=["E_sat"])
+K_sat = UniformPrior(150.0, 300.0, parameter_names=["K_sat"])
+Q_sat = UniformPrior(-500.0, 1100.0, parameter_names=["Q_sat"])
+Z_sat = UniformPrior(-2500.0, 1500.0, parameter_names=["Z_sat"])
+E_sym = UniformPrior(28.0, 45.0, parameter_names=["E_sym"])
+L_sym = UniformPrior(10.0, 200.0, parameter_names=["L_sym"])
+K_sym = UniformPrior(-400.0, 200.0, parameter_names=["K_sym"])
+Q_sym = UniformPrior(-1000.0, 1500.0, parameter_names=["Q_sym"])
+Z_sym = UniformPrior(-2000.0, 1500.0, parameter_names=["Z_sym"])
+
+# Break density between meta-model and peakCSE regions [fm^-3]
+nbreak = UniformPrior(0.16, 0.32, parameter_names=["nbreak"])
+
+# peakCSE parameters - priors from arXiv:2507.13039 (Tab. astro_prior)
+# Gaussian peak amplitude c^2_{s,peak}
+gaussian_peak = UniformPrior(0.1, 1.0, parameter_names=["gaussian_peak"])
+# Gaussian peak center n_peak [fm^-3]
+gaussian_mu = UniformPrior(0.32, 1.92, parameter_names=["gaussian_mu"])
+# Gaussian peak width sigma_peak [fm^-3]
+gaussian_sigma = UniformPrior(0.016, 0.8, parameter_names=["gaussian_sigma"])
+# Logistic growth rate l_sig [fm^3]
+logit_growth_rate = UniformPrior(0.1, 1.0, parameter_names=["logit_growth_rate"])
+# Logistic midpoint n_sig [fm^-3]
+logit_midpoint = UniformPrior(0.32, 5.6, parameter_names=["logit_midpoint"])

--- a/examples/inference/mm_peakcse/chiEFT/config.yaml
+++ b/examples/inference/mm_peakcse/chiEFT/config.yaml
@@ -1,0 +1,36 @@
+seed: 44
+dry_run: false
+validate_only: false
+eos:
+  type: metamodel_peak_cse
+  ndat_metamodel: 100
+  nmax_nsat: 25.0
+  ndat_CSE: 100
+  crust_name: DH
+tov:
+  type: gr
+  min_nsat_TOV: 0.75
+  ndat_TOV: 100
+  nb_masses: 100
+prior:
+  specification_file: prior.prior
+likelihoods:
+- type: constraints_eos
+  enabled: true
+- type: chieft
+  enabled: true
+  low_filename: ../../../../jesterTOV/inference/data/chiEFT/2402.04172/low.dat
+  high_filename: ../../../../jesterTOV/inference/data/chiEFT/2402.04172/high.dat
+  nb_n: 100
+sampler:
+  type: smc-rw
+  n_particles: 2000
+  n_mcmc_steps: 10
+  target_ess: 0.9
+  random_walk_sigma: 0.1
+  output_dir: ./outdir/
+postprocessing:
+  enabled: true
+  make_cornerplot: false
+  make_massradius: true
+  make_pressuredensity: true

--- a/examples/inference/mm_peakcse/chiEFT/prior.prior
+++ b/examples/inference/mm_peakcse/chiEFT/prior.prior
@@ -1,0 +1,25 @@
+# Nuclear Empirical Parameters (NEPs) - same as metamodel_cse
+E_sat = UniformPrior(-16.1, -15.9, parameter_names=["E_sat"])
+K_sat = UniformPrior(150.0, 300.0, parameter_names=["K_sat"])
+Q_sat = UniformPrior(-500.0, 1100.0, parameter_names=["Q_sat"])
+Z_sat = UniformPrior(-2500.0, 1500.0, parameter_names=["Z_sat"])
+E_sym = UniformPrior(28.0, 45.0, parameter_names=["E_sym"])
+L_sym = UniformPrior(10.0, 200.0, parameter_names=["L_sym"])
+K_sym = UniformPrior(-400.0, 200.0, parameter_names=["K_sym"])
+Q_sym = UniformPrior(-1000.0, 1500.0, parameter_names=["Q_sym"])
+Z_sym = UniformPrior(-2000.0, 1500.0, parameter_names=["Z_sym"])
+
+# Break density between meta-model and peakCSE regions [fm^-3]
+nbreak = UniformPrior(0.16, 0.32, parameter_names=["nbreak"])
+
+# peakCSE parameters - priors from arXiv:2507.13039 (Tab. astro_prior)
+# Gaussian peak amplitude c^2_{s,peak}
+gaussian_peak = UniformPrior(0.1, 1.0, parameter_names=["gaussian_peak"])
+# Gaussian peak center n_peak [fm^-3]
+gaussian_mu = UniformPrior(0.32, 1.92, parameter_names=["gaussian_mu"])
+# Gaussian peak width sigma_peak [fm^-3]
+gaussian_sigma = UniformPrior(0.016, 0.8, parameter_names=["gaussian_sigma"])
+# Logistic growth rate l_sig [fm^3]
+logit_growth_rate = UniformPrior(0.1, 1.0, parameter_names=["logit_growth_rate"])
+# Logistic midpoint n_sig [fm^-3]
+logit_midpoint = UniformPrior(0.32, 5.6, parameter_names=["logit_midpoint"])

--- a/examples/inference/mm_peakcse/prior/config.yaml
+++ b/examples/inference/mm_peakcse/prior/config.yaml
@@ -1,0 +1,33 @@
+seed: 43
+dry_run: false
+validate_only: false
+eos:
+  type: metamodel_peak_cse
+  ndat_metamodel: 100
+  nmax_nsat: 25.0
+  ndat_CSE: 100
+  crust_name: DH
+tov:
+  min_nsat_TOV: 0.75
+  ndat_TOV: 100
+  nb_masses: 100
+  type: gr
+prior:
+  specification_file: prior.prior
+likelihoods:
+- type: constraints_eos
+  enabled: true
+- type: zero
+  enabled: true
+sampler:
+  type: smc-rw
+  n_particles: 2000
+  n_mcmc_steps: 10
+  target_ess: 0.9
+  random_walk_sigma: 0.1
+  output_dir: ./outdir/
+postprocessing:
+  enabled: true
+  make_cornerplot: false
+  make_massradius: true
+  make_pressuredensity: true

--- a/examples/inference/mm_peakcse/prior/prior.prior
+++ b/examples/inference/mm_peakcse/prior/prior.prior
@@ -1,0 +1,25 @@
+# Nuclear Empirical Parameters (NEPs) - same as metamodel_cse
+E_sat = UniformPrior(-16.1, -15.9, parameter_names=["E_sat"])
+K_sat = UniformPrior(150.0, 300.0, parameter_names=["K_sat"])
+Q_sat = UniformPrior(-500.0, 1100.0, parameter_names=["Q_sat"])
+Z_sat = UniformPrior(-2500.0, 1500.0, parameter_names=["Z_sat"])
+E_sym = UniformPrior(28.0, 45.0, parameter_names=["E_sym"])
+L_sym = UniformPrior(10.0, 200.0, parameter_names=["L_sym"])
+K_sym = UniformPrior(-400.0, 200.0, parameter_names=["K_sym"])
+Q_sym = UniformPrior(-1000.0, 1500.0, parameter_names=["Q_sym"])
+Z_sym = UniformPrior(-2000.0, 1500.0, parameter_names=["Z_sym"])
+
+# Break density between meta-model and peakCSE regions [fm^-3]
+nbreak = UniformPrior(0.16, 0.32, parameter_names=["nbreak"])
+
+# peakCSE parameters - priors from arXiv:2507.13039 (Tab. astro_prior)
+# Gaussian peak amplitude c^2_{s,peak}
+gaussian_peak = UniformPrior(0.1, 1.0, parameter_names=["gaussian_peak"])
+# Gaussian peak center n_peak [fm^-3]
+gaussian_mu = UniformPrior(0.32, 1.92, parameter_names=["gaussian_mu"])
+# Gaussian peak width sigma_peak [fm^-3]
+gaussian_sigma = UniformPrior(0.016, 0.8, parameter_names=["gaussian_sigma"])
+# Logistic growth rate l_sig [fm^3]
+logit_growth_rate = UniformPrior(0.1, 1.0, parameter_names=["logit_growth_rate"])
+# Logistic midpoint n_sig [fm^-3]
+logit_midpoint = UniformPrior(0.32, 5.6, parameter_names=["logit_midpoint"])

--- a/examples/inference/mm_peakcse/radio/config.yaml
+++ b/examples/inference/mm_peakcse/radio/config.yaml
@@ -1,0 +1,41 @@
+seed: 43
+dry_run: false
+validate_only: false
+eos:
+  type: metamodel_peak_cse
+  ndat_metamodel: 100
+  nmax_nsat: 25.0
+  ndat_CSE: 100
+  crust_name: DH
+tov:
+  min_nsat_TOV: 0.75
+  ndat_TOV: 100
+  nb_masses: 100
+  type: gr
+prior:
+  specification_file: prior.prior
+likelihoods:
+- type: constraints_eos
+  enabled: true
+- type: radio
+  enabled: true
+  pulsars:
+  - name: J1614
+    mass_mean: 1.94
+    mass_std: 0.06
+  - name: J0740
+    mass_mean: 2.08
+    mass_std: 0.14
+sampler:
+  type: smc-rw
+  n_particles: 5000
+  n_mcmc_steps: 10
+  target_ess: 0.9
+  random_walk_sigma: 0.05
+  n_eos_samples: 5000
+  output_dir: ./outdir/
+postprocessing:
+  enabled: true
+  make_cornerplot: false
+  make_massradius: true
+  make_pressuredensity: true

--- a/examples/inference/mm_peakcse/radio/prior.prior
+++ b/examples/inference/mm_peakcse/radio/prior.prior
@@ -1,0 +1,25 @@
+# Nuclear Empirical Parameters (NEPs) - same as metamodel_cse
+E_sat = UniformPrior(-16.1, -15.9, parameter_names=["E_sat"])
+K_sat = UniformPrior(150.0, 300.0, parameter_names=["K_sat"])
+Q_sat = UniformPrior(-500.0, 1100.0, parameter_names=["Q_sat"])
+Z_sat = UniformPrior(-2500.0, 1500.0, parameter_names=["Z_sat"])
+E_sym = UniformPrior(28.0, 45.0, parameter_names=["E_sym"])
+L_sym = UniformPrior(10.0, 200.0, parameter_names=["L_sym"])
+K_sym = UniformPrior(-400.0, 200.0, parameter_names=["K_sym"])
+Q_sym = UniformPrior(-1000.0, 1500.0, parameter_names=["Q_sym"])
+Z_sym = UniformPrior(-2000.0, 1500.0, parameter_names=["Z_sym"])
+
+# Break density between meta-model and peakCSE regions [fm^-3]
+nbreak = UniformPrior(0.16, 0.32, parameter_names=["nbreak"])
+
+# peakCSE parameters - priors from arXiv:2507.13039 (Tab. astro_prior)
+# Gaussian peak amplitude c^2_{s,peak}
+gaussian_peak = UniformPrior(0.1, 1.0, parameter_names=["gaussian_peak"])
+# Gaussian peak center n_peak [fm^-3]
+gaussian_mu = UniformPrior(0.32, 1.92, parameter_names=["gaussian_mu"])
+# Gaussian peak width sigma_peak [fm^-3]
+gaussian_sigma = UniformPrior(0.016, 0.8, parameter_names=["gaussian_sigma"])
+# Logistic growth rate l_sig [fm^3]
+logit_growth_rate = UniformPrior(0.1, 1.0, parameter_names=["logit_growth_rate"])
+# Logistic midpoint n_sig [fm^-3]
+logit_midpoint = UniformPrior(0.32, 5.6, parameter_names=["logit_midpoint"])

--- a/examples/inference/smc_random_walk/chiEFT_peakCSE/config.yaml
+++ b/examples/inference/smc_random_walk/chiEFT_peakCSE/config.yaml
@@ -1,0 +1,36 @@
+seed: 44
+dry_run: false
+validate_only: false
+eos:
+  type: metamodel_peak_cse
+  ndat_metamodel: 100
+  nmax_nsat: 25.0
+  ndat_CSE: 100
+  crust_name: DH
+tov:
+  type: gr
+  min_nsat_TOV: 0.75
+  ndat_TOV: 100
+  nb_masses: 100
+prior:
+  specification_file: prior.prior
+likelihoods:
+- type: constraints_eos
+  enabled: true
+- type: chieft
+  enabled: true
+  low_filename: ../../../../jesterTOV/inference/data/chiEFT/2402.04172/low.dat
+  high_filename: ../../../../jesterTOV/inference/data/chiEFT/2402.04172/high.dat
+  nb_n: 100
+sampler:
+  type: smc-rw
+  n_particles: 2000
+  n_mcmc_steps: 10
+  target_ess: 0.9
+  random_walk_sigma: 0.1
+  output_dir: ./outdir/
+postprocessing:
+  enabled: true
+  make_cornerplot: false
+  make_massradius: true
+  make_pressuredensity: true

--- a/examples/inference/smc_random_walk/chiEFT_peakCSE/prior.prior
+++ b/examples/inference/smc_random_walk/chiEFT_peakCSE/prior.prior
@@ -1,0 +1,25 @@
+# Nuclear Empirical Parameters (NEPs) - same as metamodel_cse
+E_sat = UniformPrior(-16.1, -15.9, parameter_names=["E_sat"])
+K_sat = UniformPrior(150.0, 300.0, parameter_names=["K_sat"])
+Q_sat = UniformPrior(-500.0, 1100.0, parameter_names=["Q_sat"])
+Z_sat = UniformPrior(-2500.0, 1500.0, parameter_names=["Z_sat"])
+E_sym = UniformPrior(28.0, 45.0, parameter_names=["E_sym"])
+L_sym = UniformPrior(10.0, 200.0, parameter_names=["L_sym"])
+K_sym = UniformPrior(-400.0, 200.0, parameter_names=["K_sym"])
+Q_sym = UniformPrior(-1000.0, 1500.0, parameter_names=["Q_sym"])
+Z_sym = UniformPrior(-2000.0, 1500.0, parameter_names=["Z_sym"])
+
+# Break density between meta-model and peakCSE regions [fm^-3]
+nbreak = UniformPrior(0.16, 0.32, parameter_names=["nbreak"])
+
+# peakCSE parameters - priors from arXiv:2507.13039 (Tab. astro_prior)
+# Gaussian peak amplitude c^2_{s,peak}
+gaussian_peak = UniformPrior(0.1, 1.0, parameter_names=["gaussian_peak"])
+# Gaussian peak center n_peak [fm^-3]
+gaussian_mu = UniformPrior(0.32, 1.92, parameter_names=["gaussian_mu"])
+# Gaussian peak width sigma_peak [fm^-3]
+gaussian_sigma = UniformPrior(0.016, 0.8, parameter_names=["gaussian_sigma"])
+# Logistic growth rate l_sig [fm^3]
+logit_growth_rate = UniformPrior(0.1, 1.0, parameter_names=["logit_growth_rate"])
+# Logistic midpoint n_sig [fm^-3]
+logit_midpoint = UniformPrior(0.32, 5.6, parameter_names=["logit_midpoint"])

--- a/jesterTOV/eos/metamodel/metamodel_peakCSE.py
+++ b/jesterTOV/eos/metamodel/metamodel_peakCSE.py
@@ -226,10 +226,9 @@ class MetaModel_with_peakCSE_EOS_model(Interpolate_EOS_model):
         Returns
         -------
         list[str]
-            NEP parameters + nbreak + peakCSE-specific parameters:
-            ["E_sat", "K_sat", "Q_sat", "Z_sat", "E_sym", "L_sym", "K_sym", "Q_sym", "Z_sym",
-             "nbreak", "gaussian_peak", "gaussian_mu", "gaussian_sigma",
-             "logit_growth_rate", "logit_midpoint"]
+            The 9 NEP parameters (E_sat, K_sat, Q_sat, Z_sat, E_sym, L_sym, K_sym, Q_sym,
+            Z_sym), plus nbreak, gaussian_peak, gaussian_mu, gaussian_sigma,
+            logit_growth_rate, and logit_midpoint.
         """
         return [
             "E_sat",

--- a/jesterTOV/eos/metamodel/metamodel_peakCSE.py
+++ b/jesterTOV/eos/metamodel/metamodel_peakCSE.py
@@ -6,6 +6,7 @@ from jaxtyping import Array, Float, Int
 from jesterTOV import utils
 from jesterTOV.eos.base import Interpolate_EOS_model
 from jesterTOV.eos.metamodel.base import MetaModel_EOS_model
+from jesterTOV.tov.data_classes import EOSData
 
 
 class MetaModel_with_peakCSE_EOS_model(Interpolate_EOS_model):
@@ -34,6 +35,7 @@ class MetaModel_with_peakCSE_EOS_model(Interpolate_EOS_model):
         nsat: Float = 0.16,
         nmin_MM_nsat: Float = 0.12 / 0.16,
         nmax_nsat: Float = 12,
+        max_nbreak_nsat: Float | None = None,
         ndat_metamodel: Int = 100,
         ndat_CSE: Int = 100,
         **metamodel_kwargs,
@@ -46,6 +48,12 @@ class MetaModel_with_peakCSE_EOS_model(Interpolate_EOS_model):
         extensions at high densities, designed to model phase transitions while maintaining
         consistency with perturbative QCD predictions.
 
+        The metamodel instance is created once here with a fixed maximum density,
+        then reused in each ``construct_eos`` call where its output is interpolated
+        to the actual (sampled) ``nbreak`` value. This ensures JAX compatibility
+        since no Python-level operations that require concrete values are performed
+        on traced arrays during JIT compilation.
+
         Args:
             nsat (Float, optional):
                 Nuclear saturation density :math:`n_0` [:math:`\mathrm{fm}^{-3}`].
@@ -56,6 +64,11 @@ class MetaModel_with_peakCSE_EOS_model(Interpolate_EOS_model):
             nmax_nsat (Float, optional):
                 Maximum density for EOS construction in units of :math:`n_0`.
                 Should extend to densities where pQCD limit is approached. Defaults to 12.
+            max_nbreak_nsat (Float | None, optional):
+                Maximum value of nbreak prior in units of :math:`n_0`.
+                Used to set the upper limit for the meta-model region. If None,
+                defaults to nmax_nsat. Should be set to the maximum value from the
+                nbreak prior distribution to avoid unnecessary computation. Defaults to None.
             ndat_metamodel (Int, optional):
                 Number of density points for meta-model region discretization.
                 Higher values give smoother meta-model interpolation. Defaults to 100.
@@ -71,14 +84,27 @@ class MetaModel_with_peakCSE_EOS_model(Interpolate_EOS_model):
             MetaModel_EOS_model.__init__ : Base meta-model parameters
             construct_eos : Method that defines peakCSE parameters and break density
         """
-
-        # TODO: align with new metamodel code
         self.nmax = nmax_nsat * nsat
         self.ndat_CSE = ndat_CSE
         self.nsat = nsat
         self.nmin_MM_nsat = nmin_MM_nsat
         self.ndat_metamodel = ndat_metamodel
-        self.metamodel_kwargs = metamodel_kwargs
+
+        # Use max_nbreak_nsat if provided, otherwise default to nmax_nsat.
+        # This allows optimization when the nbreak prior has a tighter upper bound.
+        metamodel_max_nsat = (
+            max_nbreak_nsat if max_nbreak_nsat is not None else nmax_nsat
+        )
+
+        # Create the metamodel instance once with max density from nbreak prior.
+        # This will be reused in construct_eos and interpolated to actual nbreak.
+        self.metamodel = MetaModel_EOS_model(
+            nsat=nsat,
+            nmin_MM_nsat=nmin_MM_nsat,
+            nmax_nsat=metamodel_max_nsat,
+            ndat=ndat_metamodel,
+            **metamodel_kwargs,
+        )
 
     def construct_eos(self, params: dict):
         r"""
@@ -110,31 +136,36 @@ class MetaModel_with_peakCSE_EOS_model(Interpolate_EOS_model):
             and asymptotic consistency with the pQCD conformal limit :math:`c_s^2 = 1/3`.
         """
 
-        # Initializate the MetaModel part up to n_break
-        metamodel = MetaModel_EOS_model(
-            nsat=self.nsat,
-            nmin_MM_nsat=self.nmin_MM_nsat,
-            nmax_nsat=params["nbreak"] / self.nsat,
-            ndat=self.ndat_metamodel,
-            **self.metamodel_kwargs,
-        )
-
-        # Construct the metamodel part:
-        mm_output = metamodel.construct_eos(params)
+        # Construct the metamodel part using the pre-instantiated metamodel.
+        # This gives us the full range up to max_nbreak (fixed, not traced).
+        mm_output = self.metamodel.construct_eos(params)
         # MetaModel guarantees mu is populated
-        mu_metamodel: Float[Array, "n_points"] = mm_output.mu  # type: ignore[assignment]
+        mu_metamodel_full: Float[Array, "n_points"] = mm_output.mu  # type: ignore[assignment]
 
-        # Convert units back for CSE initialization
-        n_metamodel = mm_output.ns / utils.fm_inv3_to_geometric
-        p_metamodel = mm_output.ps / utils.MeV_fm_inv3_to_geometric
-        e_metamodel = mm_output.es / utils.MeV_fm_inv3_to_geometric
-        cs2_metamodel = mm_output.cs2
+        # Convert units back for interpolation
+        n_metamodel_full = mm_output.ns / utils.fm_inv3_to_geometric
+        p_metamodel_full = mm_output.ps / utils.MeV_fm_inv3_to_geometric
+        e_metamodel_full = mm_output.es / utils.MeV_fm_inv3_to_geometric
+        cs2_metamodel_full = mm_output.cs2
+
+        # Re-interpolate to a fixed-size array up to nbreak.
+        # This maintains JAX compatibility while allowing variable nbreak.
+        nbreak = params["nbreak"]
+        n_metamodel = jnp.linspace(
+            n_metamodel_full[0], nbreak, self.ndat_metamodel, endpoint=True
+        )
+        p_metamodel = jnp.interp(n_metamodel, n_metamodel_full, p_metamodel_full)
+        e_metamodel = jnp.interp(n_metamodel, n_metamodel_full, e_metamodel_full)
+        mu_metamodel: Float[Array, "n_points"] = jnp.interp(
+            n_metamodel, n_metamodel_full, mu_metamodel_full
+        )
+        cs2_metamodel = jnp.interp(n_metamodel, n_metamodel_full, cs2_metamodel_full)
 
         # Get values at break density
-        p_break = jnp.interp(params["nbreak"], n_metamodel, p_metamodel)
-        e_break = jnp.interp(params["nbreak"], n_metamodel, e_metamodel)
-        mu_break = jnp.interp(params["nbreak"], n_metamodel, mu_metamodel)
-        cs2_break = jnp.interp(params["nbreak"], n_metamodel, cs2_metamodel)
+        p_break = jnp.interp(nbreak, n_metamodel, p_metamodel)
+        e_break = jnp.interp(nbreak, n_metamodel, e_metamodel)
+        mu_break = jnp.interp(nbreak, n_metamodel, mu_metamodel)
+        cs2_break = jnp.interp(nbreak, n_metamodel, cs2_metamodel)
 
         # Define the speed-of-sound of the extension portion
         # the model is taken from arXiv:1812.08188
@@ -179,8 +210,6 @@ class MetaModel_with_peakCSE_EOS_model(Interpolate_EOS_model):
 
         ns, ps, hs, es, dloge_dlogps = self.interpolate_eos(n, p, e)
 
-        from jesterTOV.tov.data_classes import EOSData
-
         return EOSData(
             ns=ns,
             ps=ps,
@@ -190,6 +219,35 @@ class MetaModel_with_peakCSE_EOS_model(Interpolate_EOS_model):
             cs2=cs2,
             mu=mu,
         )
+
+    def get_required_parameters(self) -> list[str]:
+        """Return list of parameters required by MetaModel with peakCSE.
+
+        Returns
+        -------
+        list[str]
+            NEP parameters + nbreak + peakCSE-specific parameters:
+            ["E_sat", "K_sat", "Q_sat", "Z_sat", "E_sym", "L_sym", "K_sym", "Q_sym", "Z_sym",
+             "nbreak", "gaussian_peak", "gaussian_mu", "gaussian_sigma",
+             "logit_growth_rate", "logit_midpoint"]
+        """
+        return [
+            "E_sat",
+            "K_sat",
+            "Q_sat",
+            "Z_sat",
+            "E_sym",
+            "L_sym",
+            "K_sym",
+            "Q_sym",
+            "Z_sym",
+            "nbreak",
+            "gaussian_peak",
+            "gaussian_mu",
+            "gaussian_sigma",
+            "logit_growth_rate",
+            "logit_midpoint",
+        ]
 
     def offset_calc(self, nbreak, cs2_break, params):
         gaussian_part = params["gaussian_peak"] * jnp.exp(

--- a/jesterTOV/eos/metamodel/metamodel_peakCSE.py
+++ b/jesterTOV/eos/metamodel/metamodel_peakCSE.py
@@ -84,6 +84,12 @@ class MetaModel_with_peakCSE_EOS_model(Interpolate_EOS_model):
             MetaModel_EOS_model.__init__ : Base meta-model parameters
             construct_eos : Method that defines peakCSE parameters and break density
         """
+        if max_nbreak_nsat is not None and not (0 < max_nbreak_nsat <= nmax_nsat):
+            raise ValueError(
+                f"max_nbreak_nsat must satisfy 0 < max_nbreak_nsat <= nmax_nsat, "
+                f"got max_nbreak_nsat={max_nbreak_nsat}, nmax_nsat={nmax_nsat}."
+            )
+
         self.nmax = nmax_nsat * nsat
         self.ndat_CSE = ndat_CSE
         self.nsat = nsat
@@ -188,25 +194,26 @@ class MetaModel_with_peakCSE_EOS_model(Interpolate_EOS_model):
                 )
             )
         )
-        # Compute n, p, e for peakCSE (number densities in unit of fm^-3)
+        # Compute n, p, e for peakCSE (number densities in unit of fm^-3).
+        # n_CSE starts at nbreak (same as the last point of n_metamodel), so we drop
+        # index 0 when concatenating to avoid a duplicate density value at nbreak.
         n_CSE = jnp.logspace(
             jnp.log10(params["nbreak"]), jnp.log10(self.nmax), num=self.ndat_CSE
         )
         cs2_CSE = cs2_extension_function(n_CSE)
 
-        # We add a very small number to avoid problems with duplicates below
-        mu_CSE = mu_break * jnp.exp(utils.cumtrapz(cs2_CSE / n_CSE, n_CSE)) + 1e-6
-        p_CSE = p_break + utils.cumtrapz(cs2_CSE * mu_CSE, n_CSE) + 1e-6
-        e_CSE = e_break + utils.cumtrapz(mu_CSE, n_CSE) + 1e-6
+        mu_CSE = mu_break * jnp.exp(utils.cumtrapz(cs2_CSE / n_CSE, n_CSE))
+        p_CSE = p_break + utils.cumtrapz(cs2_CSE * mu_CSE, n_CSE)
+        e_CSE = e_break + utils.cumtrapz(mu_CSE, n_CSE)
 
-        # Combine metamodel and CSE data
-        n = jnp.concatenate((n_metamodel, n_CSE))
-        p = jnp.concatenate((p_metamodel, p_CSE))
-        e = jnp.concatenate((e_metamodel, e_CSE))
+        # Combine metamodel and CSE data, skipping the first CSE point (= nbreak)
+        # which duplicates the last metamodel point.
+        n = jnp.concatenate((n_metamodel, n_CSE[1:]))
+        p = jnp.concatenate((p_metamodel, p_CSE[1:]))
+        e = jnp.concatenate((e_metamodel, e_CSE[1:]))
 
-        # TODO: let's decide whether we want to save cs2 and mu or just use them for computation and then discard them.
-        mu = jnp.concatenate((mu_metamodel, mu_CSE))
-        cs2 = jnp.concatenate((cs2_metamodel, cs2_CSE))
+        mu = jnp.concatenate((mu_metamodel, mu_CSE[1:]))
+        cs2 = jnp.concatenate((cs2_metamodel, cs2_CSE[1:]))
 
         ns, ps, hs, es, dloge_dlogps = self.interpolate_eos(n, p, e)
 

--- a/jesterTOV/inference/config/schema.py
+++ b/jesterTOV/inference/config/schema.py
@@ -31,6 +31,7 @@ from .schemas.eos import (
     BaseMetamodelEOSConfig,
     MetamodelEOSConfig,
     MetamodelCSEEOSConfig,
+    MetamodelPeakCSEEOSConfig,
     SpectralEOSConfig,
     EOSConfig,
 )
@@ -228,6 +229,7 @@ __all__ = [
     "BaseMetamodelEOSConfig",
     "MetamodelEOSConfig",
     "MetamodelCSEEOSConfig",
+    "MetamodelPeakCSEEOSConfig",
     "SpectralEOSConfig",
     "EOSConfig",
     # TOV

--- a/jesterTOV/inference/config/schemas/eos.py
+++ b/jesterTOV/inference/config/schemas/eos.py
@@ -104,6 +104,26 @@ class MetamodelCSEEOSConfig(BaseMetamodelEOSConfig):
         return v
 
 
+class MetamodelPeakCSEEOSConfig(BaseMetamodelEOSConfig):
+    """Configuration for MetaModel with peakCSE extension.
+
+    Attributes
+    ----------
+    type : Literal["metamodel_peak_cse"]
+        EOS type identifier
+    ndat_CSE : int
+        Number of density grid points for the peakCSE region (default: 100)
+    max_nbreak_nsat : float | None
+        Maximum allowed breaking density in units of nsat (default: None,
+        meaning no upper bound beyond the prior). If specified, the metamodel
+        grid is only computed up to this density, which can speed up inference.
+    """
+
+    type: Literal["metamodel_peak_cse"] = "metamodel_peak_cse"
+    ndat_CSE: int = 100
+    max_nbreak_nsat: float | None = None
+
+
 class SpectralEOSConfig(BaseEOSConfig):
     r"""Configuration for Spectral Decomposition EOS.
 
@@ -151,6 +171,11 @@ class SpectralEOSConfig(BaseEOSConfig):
 
 # Discriminated union of all EOS types
 EOSConfig = Annotated[
-    Union[MetamodelEOSConfig, MetamodelCSEEOSConfig, SpectralEOSConfig],
+    Union[
+        MetamodelEOSConfig,
+        MetamodelCSEEOSConfig,
+        MetamodelPeakCSEEOSConfig,
+        SpectralEOSConfig,
+    ],
     Discriminator("type"),
 ]

--- a/jesterTOV/inference/priors/parser.py
+++ b/jesterTOV/inference/priors/parser.py
@@ -32,6 +32,7 @@ class ParsedPrior:
 def parse_prior_file(
     prior_file: Union[str, Path],
     nb_CSE: int = 0,
+    include_nbreak: bool = False,
 ) -> ParsedPrior:
     """Parse .prior file (Python format) and return a :class:`ParsedPrior`.
 
@@ -140,9 +141,9 @@ def parse_prior_file(
         # Always include NEP parameters (_sat and _sym)
         if param_name.endswith("_sat") or param_name.endswith("_sym"):
             prior_list.append(prior)
-        # Include nbreak only if nb_CSE > 0
+        # Include nbreak if nb_CSE > 0 or if explicitly requested (e.g. for peakCSE)
         elif param_name == "nbreak":
-            if nb_CSE > 0:
+            if nb_CSE > 0 or include_nbreak:
                 prior_list.append(prior)
         else:
             # Include any other parameters not handled by special cases

--- a/jesterTOV/inference/run_inference.py
+++ b/jesterTOV/inference/run_inference.py
@@ -19,6 +19,7 @@ from .config.parser import load_config
 from .config.schema import (
     InferenceConfig,
     MetamodelCSEEOSConfig,
+    MetamodelPeakCSEEOSConfig,
     BaseMetamodelEOSConfig,
     GWLikelihoodConfig,
     GWEventConfig,
@@ -119,6 +120,8 @@ def setup_prior(config: InferenceConfig) -> tuple[CombinePrior, dict[str, float]
 
     # Determine conditional parameters
     nb_CSE = config.eos.nb_CSE if isinstance(config.eos, MetamodelCSEEOSConfig) else 0
+    # peakCSE uses nbreak as a core parameter (not gated by nb_CSE)
+    include_nbreak = isinstance(config.eos, MetamodelPeakCSEEOSConfig)
 
     # Check if GW or NICER likelihoods are enabled (both need _random_key)
     # Note: the default `gw` and `nicer` likelihoods do NOT need
@@ -133,6 +136,7 @@ def setup_prior(config: InferenceConfig) -> tuple[CombinePrior, dict[str, float]
     parsed = parse_prior_file(
         config.prior.specification_file,
         nb_CSE=nb_CSE,
+        include_nbreak=include_nbreak,
     )
     prior = parsed.prior
     fixed_params = parsed.fixed_params
@@ -719,6 +723,9 @@ def main(config_path: str) -> None:
     logger.info(f"EOS type: {config.eos.type}")
     if isinstance(config.eos, MetamodelCSEEOSConfig):
         logger.info(f"  nb_CSE: {config.eos.nb_CSE}")
+        if config.eos.max_nbreak_nsat is not None:
+            logger.info(f"  max_nbreak_nsat: {config.eos.max_nbreak_nsat:.4f} n_sat")
+    if isinstance(config.eos, MetamodelPeakCSEEOSConfig):
         if config.eos.max_nbreak_nsat is not None:
             logger.info(f"  max_nbreak_nsat: {config.eos.max_nbreak_nsat:.4f} n_sat")
     if isinstance(config.eos, BaseMetamodelEOSConfig):

--- a/jesterTOV/inference/transforms/transform.py
+++ b/jesterTOV/inference/transforms/transform.py
@@ -9,6 +9,7 @@ from jesterTOV.eos.base import Interpolate_EOS_model
 from jesterTOV.eos.metamodel import (
     MetaModel_EOS_model,
     MetaModel_with_CSE_EOS_model,
+    MetaModel_with_peakCSE_EOS_model,
 )
 from jesterTOV.eos.spectral import SpectralDecomposition_EOS_model
 from jesterTOV.tov.base import TOVSolverBase
@@ -18,6 +19,7 @@ from jesterTOV.inference.config.schema import (
     BaseEOSConfig,
     MetamodelEOSConfig,
     MetamodelCSEEOSConfig,
+    MetamodelPeakCSEEOSConfig,
     SpectralEOSConfig,
     BaseTOVConfig,
     GRTOVConfig,
@@ -246,6 +248,17 @@ class JesterTransform(NtoMTransform):
                 ndat_metamodel=config.ndat_metamodel,
                 ndat_CSE=config.ndat_CSE,
                 nb_CSE=config.nb_CSE,
+                crust_name=config.crust_name,
+            )
+
+        elif isinstance(config, MetamodelPeakCSEEOSConfig):
+            return MetaModel_with_peakCSE_EOS_model(
+                nsat=0.16,
+                nmin_MM_nsat=config.nmin_MM_nsat,
+                nmax_nsat=config.nmax_nsat,
+                max_nbreak_nsat=max_nbreak_nsat,
+                ndat_metamodel=config.ndat_metamodel,
+                ndat_CSE=config.ndat_CSE,
                 crust_name=config.crust_name,
             )
 

--- a/tests/test_inference/test_transforms.py
+++ b/tests/test_inference/test_transforms.py
@@ -7,6 +7,7 @@ import jax.numpy as jnp
 from jesterTOV.inference.config.schema import (
     MetamodelEOSConfig,
     MetamodelCSEEOSConfig,
+    MetamodelPeakCSEEOSConfig,
     SpectralEOSConfig,
     GRTOVConfig,
 )
@@ -75,6 +76,55 @@ class TestJesterTransform:
 
         assert transform is not None
         assert "SpectralDecomposition_EOS_model" in transform.get_eos_type()
+
+    def test_from_config_metamodel_peak_cse(self):
+        """Test creating MetaModel+peakCSE transform via from_config."""
+        eos_config = MetamodelPeakCSEEOSConfig(
+            type="metamodel_peak_cse",
+            ndat_metamodel=100,
+            nmax_nsat=25.0,
+            ndat_CSE=100,
+            crust_name="DH",
+        )
+        tov_config = GRTOVConfig(
+            type="gr",
+            min_nsat_TOV=0.75,
+            ndat_TOV=100,
+        )
+
+        transform = JesterTransform.from_config(eos_config, tov_config)
+
+        assert transform is not None
+        assert "MetaModel_with_peakCSE_EOS_model" in transform.get_eos_type()
+        assert transform.ndat_TOV == 100
+
+    def test_get_parameter_names_metamodel_peak_cse(self):
+        """Test that MetaModel+peakCSE transform reports correct parameter names."""
+        eos_config = MetamodelPeakCSEEOSConfig(type="metamodel_peak_cse")
+        tov_config = GRTOVConfig()
+
+        transform = JesterTransform.from_config(eos_config, tov_config)
+        param_names = transform.get_parameter_names()
+
+        expected_params = [
+            "E_sat",
+            "K_sat",
+            "Q_sat",
+            "Z_sat",
+            "E_sym",
+            "L_sym",
+            "K_sym",
+            "Q_sym",
+            "Z_sym",
+            "nbreak",
+            "gaussian_peak",
+            "gaussian_mu",
+            "gaussian_sigma",
+            "logit_growth_rate",
+            "logit_midpoint",
+        ]
+        for param in expected_params:
+            assert param in param_names, f"Missing parameter: {param}"
 
     def test_invalid_eos_type_fails(self):
         """Test that unknown EOS config type raises ValueError at runtime."""
@@ -265,6 +315,37 @@ class TestJesterTransformIntegration:
         assert max_mass > 1.0, f"Maximum mass {max_mass} too low"
 
         # CSE should allow higher maximum masses than MetaModel alone
+        assert max_mass < 3.5, f"Maximum mass {max_mass} too high - likely unphysical"
+
+    @pytest.mark.slow
+    def test_metamodel_peak_cse_forward_realistic_params(self, realistic_nep_stiff):
+        """Test MetaModel+peakCSE forward transform with realistic parameters."""
+        eos_config = MetamodelPeakCSEEOSConfig(
+            type="metamodel_peak_cse",
+            ndat_metamodel=100,
+            nmax_nsat=25.0,
+            ndat_CSE=100,
+        )
+        tov_config = GRTOVConfig(ndat_TOV=100)
+
+        transform = JesterTransform.from_config(eos_config, tov_config)
+
+        params = realistic_nep_stiff.copy()
+        params["nbreak"] = 0.24
+        params["gaussian_peak"] = 0.3
+        params["gaussian_mu"] = 0.5
+        params["gaussian_sigma"] = 0.15
+        params["logit_growth_rate"] = 5.0
+        params["logit_midpoint"] = 1.5
+
+        result = transform.forward(params)
+
+        assert "masses_EOS" in result
+        assert "radii_EOS" in result
+        assert "Lambdas_EOS" in result
+
+        max_mass = jnp.max(result["masses_EOS"])
+        assert max_mass > 1.0, f"Maximum mass {max_mass} too low"
         assert max_mass < 3.5, f"Maximum mass {max_mass} too high - likely unphysical"
 
     def test_transform_preserves_input_parameters(self, realistic_nep_stiff):


### PR DESCRIPTION
The MM+peakCSE was implemented as EOS model, but was not fully integrated into the inference workflow yet. This PR fixes that 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for peakCSE equation of state metamodel variant, enabling inference with combined metamodel and peak approaches
  * Introduced example configurations for gravitational wave event GW170817 and multiple pulsar observations (NICER and radio)
  * Added example workflows combining EOS constraints with various observational likelihoods and sampling strategies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->