### PR TITLE
Remove redundant anisotropy model

### DIFF
--- a/examples/inference/anisotropy/GW170817/prior.prior
+++ b/examples/inference/anisotropy/GW170817/prior.prior
@@ -10,9 +10,6 @@ Z_sym = UniformPrior(-2000.0, 1500.0, parameter_names=["Z_sym"])
 nbreak = UniformPrior(0.16, 0.32, parameter_names=["nbreak"])
 
 # Anisotropy TOV solver params
-gamma = Fixed(0.0, parameter_names=["gamma"])
 lambda_BL = Fixed(0.0, parameter_names=["lambda_BL"])
 lambda_DY = UniformPrior(-0.5, 0.5, parameter_names=["lambda_DY"])
 lambda_HB = Fixed(1.0, parameter_names=["lambda_HB"])
-alpha = Fixed(0.0, parameter_names=["alpha"])
-beta = Fixed(0.0, parameter_names=["beta"])

--- a/examples/inference/anisotropy/NICER_J0030/prior.prior
+++ b/examples/inference/anisotropy/NICER_J0030/prior.prior
@@ -10,9 +10,6 @@ Z_sym = UniformPrior(-2000.0, 1500.0, parameter_names=["Z_sym"])
 nbreak = UniformPrior(0.16, 0.32, parameter_names=["nbreak"])
 
 # Anisotropy TOV solver params
-gamma = Fixed(0.0, parameter_names=["gamma"])
 lambda_BL = Fixed(0.0, parameter_names=["lambda_BL"])
 lambda_DY = UniformPrior(-0.5, 0.5, parameter_names=["lambda_DY"])
 lambda_HB = Fixed(1.0, parameter_names=["lambda_HB"])
-alpha = Fixed(0.0, parameter_names=["alpha"])
-beta = Fixed(0.0, parameter_names=["beta"])

--- a/examples/inference/anisotropy/NICER_J0740/prior.prior
+++ b/examples/inference/anisotropy/NICER_J0740/prior.prior
@@ -10,9 +10,6 @@ Z_sym = UniformPrior(-2000.0, 1500.0, parameter_names=["Z_sym"])
 nbreak = UniformPrior(0.16, 0.32, parameter_names=["nbreak"])
 
 # Anisotropy TOV solver params
-gamma = Fixed(0.0, parameter_names=["gamma"])
 lambda_BL = Fixed(0.0, parameter_names=["lambda_BL"])
 lambda_DY = UniformPrior(-0.5, 0.5, parameter_names=["lambda_DY"])
 lambda_HB = Fixed(1.0, parameter_names=["lambda_HB"])
-alpha = Fixed(0.0, parameter_names=["alpha"])
-beta = Fixed(0.0, parameter_names=["beta"])

--- a/examples/inference/anisotropy/prior/prior.prior
+++ b/examples/inference/anisotropy/prior/prior.prior
@@ -10,9 +10,6 @@ Z_sym = UniformPrior(-2000.0, 1500.0, parameter_names=["Z_sym"])
 nbreak = UniformPrior(0.16, 0.32, parameter_names=["nbreak"])
 
 # Anisotropy TOV solver params
-gamma = Fixed(0.0, parameter_names=["gamma"])
 lambda_BL = Fixed(0.0, parameter_names=["lambda_BL"])
 lambda_DY = UniformPrior(-0.5, 0.5, parameter_names=["lambda_DY"])
 lambda_HB = Fixed(1.0, parameter_names=["lambda_HB"])
-alpha = Fixed(0.0, parameter_names=["alpha"])
-beta = Fixed(0.0, parameter_names=["beta"])

--- a/examples/inference/anisotropy/radio/prior.prior
+++ b/examples/inference/anisotropy/radio/prior.prior
@@ -10,9 +10,6 @@ Z_sym = UniformPrior(-2000.0, 1500.0, parameter_names=["Z_sym"])
 nbreak = UniformPrior(0.16, 0.32, parameter_names=["nbreak"])
 
 # Anisotropy TOV solver params
-gamma = Fixed(0.0, parameter_names=["gamma"])
 lambda_BL = Fixed(0.0, parameter_names=["lambda_BL"])
 lambda_DY = UniformPrior(-0.5, 0.5, parameter_names=["lambda_DY"])
 lambda_HB = Fixed(1.0, parameter_names=["lambda_HB"])
-alpha = Fixed(0.0, parameter_names=["alpha"])
-beta = Fixed(0.0, parameter_names=["beta"])

--- a/jesterTOV/tov/anisotropy.py
+++ b/jesterTOV/tov/anisotropy.py
@@ -20,7 +20,7 @@ from jesterTOV.tov.base import TOVSolverBase
 from jesterTOV.tov.data_classes import EOSData, TOVSolution
 
 
-def _sigma_func(p, e, m, r, lambda_BL, lambda_DY, lambda_HB, gamma, alpha, beta):
+def _sigma_func(p, e, m, r, lambda_BL, lambda_DY, lambda_HB):
     r"""
     Compute the non-GR correction term sigma for post-TOV equations.
 
@@ -33,7 +33,6 @@ def _sigma_func(p, e, m, r, lambda_BL, lambda_DY, lambda_HB, gamma, alpha, beta)
     - **Bowers-and-Liang**: :math:`\sigma_{\mathrm{BL}} = -\frac{\lambda_{\mathrm{BL}}\epsilon^2 r^2}{3}\left(1 + \frac{3p}{\epsilon}\right)\frac{\left(1 + \frac{p}{\epsilon}\right)}{\left(1 - \frac{2M}{r}\right)}`
     - **Horvat et al.**: :math:`\sigma_{\mathrm{DY}} = \lambda_{\mathrm{DY}} \frac{2m}{r} p`
     - **Cosenza et al.**: :math:`\sigma_{\mathrm{HB}} = -(\frac{1}{\lambda_{\mathrm{HB}}} - 1) \frac{r}{2} \frac{dp}{dr}`
-    - **Post-Newtonian**: :math:`\sigma_{\mathrm{PN}} = \gamma \frac{2m}{r} p \tanh(\alpha(\frac{m}{r} - \beta))`
 
     Parameters
     ----------
@@ -51,12 +50,6 @@ def _sigma_func(p, e, m, r, lambda_BL, lambda_DY, lambda_HB, gamma, alpha, beta)
         Doneva-Yazadjiev coupling parameter
     lambda_HB : float
         Herrera-Barreto coupling parameter
-    gamma : float
-        Post-Newtonian amplitude parameter
-    alpha : float
-        Post-Newtonian steepness parameter
-    beta : float
-        Post-Newtonian transition point parameter
 
     Returns
     -------
@@ -72,8 +65,6 @@ def _sigma_func(p, e, m, r, lambda_BL, lambda_DY, lambda_HB, gamma, alpha, beta)
     sigma += -lambda_BL * r * r / 3.0 * (e + 3.0 * p) * (e + p) * A
     sigma += lambda_DY * 2.0 * m / r * p
     sigma += -(1.0 / lambda_HB - 1.0) * r / 2.0 * dpdr
-    # post-Newtonian modification
-    sigma += gamma * 2.0 * m / r * p * jnp.tanh(alpha * (m / r - beta))
     return sigma
 
 
@@ -117,9 +108,6 @@ def _tov_ode(h, y, eos):
         eos["lambda_BL"],
         eos["lambda_DY"],
         eos["lambda_HB"],
-        eos["gamma"],
-        eos["alpha"],
-        eos["beta"],
     )
     dsigmadp_fn = jax.grad(_sigma_func, argnums=0)  # Gradient w.r.t. p
     dsigmade_fn = jax.grad(_sigma_func, argnums=1)  # Gradient w.r.t. e
@@ -131,9 +119,6 @@ def _tov_ode(h, y, eos):
         eos["lambda_BL"],
         eos["lambda_DY"],
         eos["lambda_HB"],
-        eos["gamma"],
-        eos["alpha"],
-        eos["beta"],
     )
     dsigmadp += dedp * dsigmade_fn(
         p,
@@ -143,9 +128,6 @@ def _tov_ode(h, y, eos):
         eos["lambda_BL"],
         eos["lambda_DY"],
         eos["lambda_HB"],
-        eos["gamma"],
-        eos["alpha"],
-        eos["beta"],
     )
 
     A = 1.0 / (1.0 - 2.0 * m / r)
@@ -235,7 +217,6 @@ class AnisotropyTOVSolver(TOVSolverBase):
         - Bowers-and-Liang corrections (lambda_BL)
         - Horvat et al. corrections (lambda_DY)
         - Cosenza et al. corrections (lambda_HB)
-        - Post-Newtonian corrections (gamma, alpha, beta)
     """
 
     def solve(
@@ -266,9 +247,6 @@ class AnisotropyTOVSolver(TOVSolverBase):
         lambda_BL = tov_params["lambda_BL"]
         lambda_DY = tov_params["lambda_DY"]
         lambda_HB = tov_params["lambda_HB"]
-        gamma = tov_params["gamma"]
-        alpha = tov_params["alpha"]
-        beta = tov_params["beta"]
 
         # Convert EOSData to dictionary for ODE solver
         eos_dict = {
@@ -280,9 +258,6 @@ class AnisotropyTOVSolver(TOVSolverBase):
             "lambda_BL": lambda_BL,
             "lambda_DY": lambda_DY,
             "lambda_HB": lambda_HB,
-            "gamma": gamma,
-            "alpha": alpha,
-            "beta": beta,
         }
 
         # Extract EOS arrays
@@ -335,9 +310,9 @@ class AnisotropyTOVSolver(TOVSolverBase):
 
     def get_required_parameters(self) -> list[str]:
         """
-        Post-TOV requires 6 additional theory parameters.
+        Post-TOV requires 3 additional theory parameters.
 
         Returns:
-            list[str]: ["lambda_BL", "lambda_DY", "lambda_HB", "gamma", "alpha", "beta"]
+            list[str]: ["lambda_BL", "lambda_DY", "lambda_HB"]
         """
-        return ["lambda_BL", "lambda_DY", "lambda_HB", "gamma", "alpha", "beta"]
+        return ["lambda_BL", "lambda_DY", "lambda_HB"]

--- a/tests/test_inference/test_anisotropy_tov_inference.py
+++ b/tests/test_inference/test_anisotropy_tov_inference.py
@@ -128,8 +128,8 @@ class TestAnisotropyTOVTransformFactory:
         assert isinstance(transform.tov_solver, AnisotropyTOVSolver)
 
     def test_anisotropy_required_parameters(self):
-        """AnisotropyTOVSolver.get_required_parameters() must return all 6 coupling params."""
-        expected = ["lambda_BL", "lambda_DY", "lambda_HB", "gamma", "alpha", "beta"]
+        """AnisotropyTOVSolver.get_required_parameters() must return all 3 coupling params."""
+        expected = ["lambda_BL", "lambda_DY", "lambda_HB"]
         assert AnisotropyTOVSolver().get_required_parameters() == expected
 
     def test_transform_parameter_names_include_anisotropy_params(self):
@@ -152,7 +152,7 @@ class TestAnisotropyTOVTransformFactory:
         ]:
             assert nep in required
         # All anisotropy params are now required
-        for p in ["lambda_BL", "lambda_DY", "lambda_HB", "gamma", "alpha", "beta"]:
+        for p in ["lambda_BL", "lambda_DY", "lambda_HB"]:
             assert p in required
 
 
@@ -171,20 +171,17 @@ class TestAnisotropyParameterValidation:
         return config
 
     def test_neps_only_prior_fails_for_anisotropy(self):
-        """Prior with only 9 NEPs raises ValueError since all 6 anisotropy params are required."""
+        """Prior with only 9 NEPs raises ValueError since all 3 anisotropy params are required."""
         prior = CombinePrior(_nep_priors())  # type: ignore[arg-type]
         with pytest.raises(ValueError, match="missing params"):
             setup_transform(self._make_config(), prior=prior)
 
     def test_neps_plus_all_anisotropy_params_succeeds(self):
-        """Prior with 9 NEPs + all 6 anisotropy params passes validation."""
+        """Prior with 9 NEPs + all 3 anisotropy params passes validation."""
         priors = _nep_priors() + [
             UniformPrior(0.0, 0.2, parameter_names=["lambda_BL"]),
             UniformPrior(0.0, 0.1, parameter_names=["lambda_DY"]),
             UniformPrior(0.9, 1.1, parameter_names=["lambda_HB"]),
-            UniformPrior(-0.1, 0.1, parameter_names=["gamma"]),
-            UniformPrior(5.0, 15.0, parameter_names=["alpha"]),
-            UniformPrior(0.1, 0.5, parameter_names=["beta"]),
         ]
         prior = CombinePrior(priors)  # type: ignore[arg-type]
         transform = setup_transform(self._make_config(), prior=prior)
@@ -223,9 +220,6 @@ class TestAnisotropyKwargsPassthrough:
             "lambda_BL": 0.0,
             "lambda_DY": 0.0,
             "lambda_HB": 1.0,
-            "gamma": 0.0,
-            "alpha": 10.0,
-            "beta": 0.3,
         }
         aniso_sol = AnisotropyTOVSolver().solve(eos_data, pc, gr_params)
 
@@ -242,37 +236,30 @@ class TestAnisotropyKwargsPassthrough:
             "lambda_BL": 0.1,
             "lambda_DY": 0.05,
             "lambda_HB": 1.0,
-            "gamma": 0.0,
-            "alpha": 10.0,
-            "beta": 0.3,
         }
         aniso_sol = AnisotropyTOVSolver().solve(eos_data, pc, mg_params)
 
         diff = float(abs(gr_sol.M - aniso_sol.M) / gr_sol.M)
         assert diff > 1e-6, "Non-GR corrections should shift the mass"
 
-    def test_transform_forward_passes_gamma(self):
-        """construct_eos_and_solve_tov must pass gamma from the param dict to the solver."""
+    def test_transform_forward_passes_lambda_DY(self):
+        """construct_eos_and_solve_tov must pass lambda_DY from the param dict to the solver."""
         transform = JesterTransform.from_config(
             eos_config=_eos_config(),
             tov_config=AnisotropyTOVConfig(type="anisotropy"),
         )
 
-        # Run transform with gamma=0 (GR limit) vs small non-zero gamma
-        # All 6 anisotropy params are required
+        # Run transform with lambda_DY=0 (GR limit) vs non-zero lambda_DY
         base_aniso = {
             "lambda_BL": 0.0,
-            "lambda_DY": 0.0,
             "lambda_HB": 1.0,
-            "alpha": 10.0,
-            "beta": 0.3,
         }
         result_gr = transform.construct_eos_and_solve_tov(
-            {**_NEP_PARAMS, **base_aniso, "gamma": 0.0}
+            {**_NEP_PARAMS, **base_aniso, "lambda_DY": 0.0}
         )
         result_mg = transform.construct_eos_and_solve_tov(
-            {**_NEP_PARAMS, **base_aniso, "gamma": 0.05}
+            {**_NEP_PARAMS, **base_aniso, "lambda_DY": 0.1}
         )
 
         mass_diff = jnp.max(jnp.abs(result_gr["masses_EOS"] - result_mg["masses_EOS"]))
-        assert float(mass_diff) > 1e-6, "gamma should shift the M-R family"
+        assert float(mass_diff) > 1e-6, "lambda_DY should shift the M-R family"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -271,9 +271,6 @@ class TestTOVIntegration:
             "lambda_BL": 0.0,
             "lambda_DY": 0.0,
             "lambda_HB": 1.0,
-            "gamma": 0.0,
-            "alpha": 10.0,
-            "beta": 0.3,
         }
         post_solution = post_solver.solve(eos_data, pc, post_params)
         M_post, R_post, k2_post = post_solution.M, post_solution.R, post_solution.k2

--- a/tests/test_ptov.py
+++ b/tests/test_ptov.py
@@ -49,9 +49,6 @@ class TestAnisotropyTOVSolver:
                 "lambda_BL": 0.0,
                 "lambda_DY": 0.0,
                 "lambda_HB": 1.0,
-                "gamma": 0.0,
-                "alpha": 10.0,
-                "beta": 0.3,
             },
         )
 
@@ -69,9 +66,6 @@ class TestAnisotropyTOVSolver:
             "lambda_BL": 0.1,
             "lambda_DY": 0.05,
             "lambda_HB": 1.2,
-            "gamma": 0.02,
-            "alpha": 10.0,
-            "beta": 0.3,
         }
 
         solution = post_solver.solve(sample_eos_data_post, pc, mg_params)
@@ -99,33 +93,21 @@ class TestAnisotropyTOVSolver:
                 "lambda_BL": 0.0,
                 "lambda_DY": 0.0,
                 "lambda_HB": 1.0,
-                "gamma": 0.0,
-                "alpha": 10.0,
-                "beta": 0.3,
             },  # GR case
             {
                 "lambda_BL": 0.1,
                 "lambda_DY": 0.0,
                 "lambda_HB": 1.0,
-                "gamma": 0.0,
-                "alpha": 10.0,
-                "beta": 0.3,
             },  # Brans-Dicke
             {
                 "lambda_BL": 0.0,
                 "lambda_DY": 0.05,
                 "lambda_HB": 1.0,
-                "gamma": 0.0,
-                "alpha": 10.0,
-                "beta": 0.3,
             },  # dCS
             {
                 "lambda_BL": 0.0,
                 "lambda_DY": 0.0,
                 "lambda_HB": 1.1,
-                "gamma": 0.0,
-                "alpha": 10.0,
-                "beta": 0.3,
             },  # Horndeski
         ]
 
@@ -163,9 +145,6 @@ class TestAnisotropyTOVSolver:
             "lambda_BL": 0.1,
             "lambda_DY": 0.05,
             "lambda_HB": 1.2,
-            "gamma": 0.02,
-            "alpha": 10.0,
-            "beta": 0.3,
         }
 
         # Solve multiple times
@@ -192,9 +171,6 @@ class TestAnisotropyTOVPhysicalConsistency:
             "lambda_BL": 0.1,
             "lambda_DY": 0.05,
             "lambda_HB": 1.2,
-            "gamma": 0.02,
-            "alpha": 10.0,
-            "beta": 0.3,
         }
 
         pressure_indices = range(15, 35, 5)
@@ -238,9 +214,6 @@ class TestAnisotropyTOVPhysicalConsistency:
             "lambda_BL": 0.0,
             "lambda_DY": 0.0,
             "lambda_HB": 1.0,
-            "gamma": 0.0,
-            "alpha": 10.0,
-            "beta": 0.3,
         }
 
         # Modified gravity case
@@ -248,9 +221,6 @@ class TestAnisotropyTOVPhysicalConsistency:
             "lambda_BL": 0.2,
             "lambda_DY": 0.1,
             "lambda_HB": 1.1,
-            "gamma": 0.05,
-            "alpha": 10.0,
-            "beta": 0.3,
         }
 
         try:
@@ -280,9 +250,6 @@ def test_post_solver_parameter_sweep(sample_eos_data_post, lambda_BL, lambda_DY)
         "lambda_BL": lambda_BL,
         "lambda_DY": lambda_DY,
         "lambda_HB": 1.0,
-        "gamma": 0.0,
-        "alpha": 10.0,
-        "beta": 0.3,
     }
 
     try:
@@ -305,7 +272,6 @@ def test_post_solver_parameter_sweep(sample_eos_data_post, lambda_BL, lambda_DY)
         ("lambda_BL", 0.1),
         ("lambda_DY", 0.05),
         ("lambda_HB", 1.1),
-        ("gamma", 0.02),
     ],
 )
 def test_post_solver_individual_mg_params(sample_eos_data_post, mg_param, value):
@@ -318,9 +284,6 @@ def test_post_solver_individual_mg_params(sample_eos_data_post, mg_param, value)
         "lambda_BL": 0.0,
         "lambda_DY": 0.0,
         "lambda_HB": 1.0,
-        "gamma": 0.0,
-        "alpha": 10.0,
-        "beta": 0.3,
     }
     mg_params[mg_param] = value
 


### PR DESCRIPTION
Closes #104 

As discussed there, the final anistropy model is a bit redundant, so to avoid confusion, this PR removes it 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the anisotropy TOV solver by removing three parameters from all inference configurations, solver implementation, examples, and tests. The solver now requires only three coupling parameters instead of six. This reduces configuration complexity and setup overhead. Model functionality is maintained with the remaining parameters, streamlining inference workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->