### PR TITLE
Add n_TOV to output and truncate in postprocessing plots

### DIFF
--- a/jesterTOV/inference/postprocessing/postprocessing.py
+++ b/jesterTOV/inference/postprocessing/postprocessing.py
@@ -167,6 +167,10 @@ def load_eos_data(outdir: str) -> Dict[str, np.ndarray]:
     p = p / utils.MeV_fm_inv3_to_geometric
     e = e / utils.MeV_fm_inv3_to_geometric
 
+    n_TOV = result.posterior.get("n_TOV", None)
+    if n_TOV is not None:
+        n_TOV = n_TOV / utils.fm_inv3_to_geometric / 0.16  # convert to n_sat
+
     log_prob = result.posterior["log_prob"]
 
     # Load prior parameters directly from saved parameter names (no magic!)
@@ -186,7 +190,7 @@ def load_eos_data(outdir: str) -> Dict[str, np.ndarray]:
             "No parameter_names found in metadata. Cornerplot may be empty. This may occur if results were saved with an older version of JESTER."
         )
 
-    output = {
+    output: Dict[str, Any] = {
         "masses": m,
         "radii": r,
         "lambdas": l,
@@ -197,6 +201,8 @@ def load_eos_data(outdir: str) -> Dict[str, np.ndarray]:
         "log_prob": log_prob,
         "prior_params": prior_params,  # General key for all parameters
     }
+    if n_TOV is not None:
+        output["n_TOV"] = n_TOV
 
     return output
 
@@ -1017,7 +1023,7 @@ def make_pressure_density_plot(
     if prior_data is not None:
         n_prior, p_prior = prior_data["densities"], prior_data["pressures"]
         for i in range(len(n_prior)):
-            mask = (n_prior[i] > 0.5) * (n_prior[i] < 6.0)
+            mask = n_prior[i] > 0.5
             plt.plot(
                 n_prior[i][mask],
                 p_prior[i][mask],
@@ -1030,6 +1036,7 @@ def make_pressure_density_plot(
     # Plot posterior with probability coloring
     m, r, l = data["masses"], data["radii"], data["lambdas"]
     n, p = data["densities"], data["pressures"]
+    n_TOV = data.get("n_TOV", None)
     log_prob = data["log_prob"]
     nb_samples = np.shape(m)[0]
 
@@ -1068,11 +1075,19 @@ def make_pressure_density_plot(
             bad_counter += 1
             continue
 
+        # n_TOV == 0 means the computation failed (nan_to_num fallback in transform)
+        if n_TOV is not None and n_TOV[i] <= 0.0:
+            bad_counter += 1
+            continue
+
         # Get color and plot
         normalized_value = norm(prob[i])
         color = cmap(normalized_value)
 
-        mask = (n[i] > 0.5) * (n[i] < 6.0)
+        if n_TOV is not None:
+            mask = (n[i] > 0.5) * (n[i] <= n_TOV[i])
+        else:
+            mask = n[i] > 0.5
         plt.plot(
             n[i][mask],
             p[i][mask],
@@ -1091,7 +1106,7 @@ def make_pressure_density_plot(
             p_inj = injection_data["p"]
             logger.info(f"Plotting injection EOS with {len(n_inj)} curves")
             for i in range(len(n_inj)):
-                mask = (n_inj[i] > 0.5) * (n_inj[i] < 6.0)
+                mask = n_inj[i] > 0.5
                 plt.plot(
                     n_inj[i][mask],
                     p_inj[i][mask],
@@ -1108,7 +1123,8 @@ def make_pressure_density_plot(
     plt.xlabel(xlabel)
     plt.ylabel(ylabel)
     plt.yscale("log")
-    plt.xlim(0.5, 6.0)
+    # NOTE: we limit at 6 nsat since that is where most interesting things happen
+    plt.xlim(left=0.5, right=6.0)
 
     # Add legend for prior and/or injection
     if prior_data is not None or injection_data is not None:
@@ -1173,7 +1189,7 @@ def make_cs2_plot(
     if prior_data is not None:
         n_prior, cs2_prior = prior_data["densities"], prior_data["cs2"]
         for i in range(len(n_prior)):
-            mask = (n_prior[i] > 0.5) * (n_prior[i] < 6.0)
+            mask = n_prior[i] > 0.5
             plt.plot(
                 n_prior[i][mask],
                 cs2_prior[i][mask],
@@ -1186,6 +1202,7 @@ def make_cs2_plot(
     # Plot posterior with probability coloring
     m, r, l = data["masses"], data["radii"], data["lambdas"]
     n, cs2 = data["densities"], data["cs2"]
+    n_TOV = data.get("n_TOV", None)
     log_prob = data["log_prob"]
     nb_samples = np.shape(m)[0]
 
@@ -1224,11 +1241,19 @@ def make_cs2_plot(
             bad_counter += 1
             continue
 
+        # n_TOV == 0 means the computation failed (nan_to_num fallback in transform)
+        if n_TOV is not None and n_TOV[i] <= 0.0:
+            bad_counter += 1
+            continue
+
         # Get color and plot
         normalized_value = norm(prob[i])
         color = cmap(normalized_value)
 
-        mask = (n[i] > 0.5) * (n[i] < 6.0)
+        if n_TOV is not None:
+            mask = (n[i] > 0.5) * (n[i] <= n_TOV[i])
+        else:
+            mask = n[i] > 0.5
         plt.plot(
             n[i][mask],
             cs2[i][mask],
@@ -1247,7 +1272,7 @@ def make_cs2_plot(
             cs2_inj = injection_data["cs2"]
             logger.info(f"Plotting injection EOS with {len(n_inj)} curves")
             for i in range(len(n_inj)):
-                mask = (n_inj[i] > 0.5) * (n_inj[i] < 6.0)
+                mask = n_inj[i] > 0.5
                 plt.plot(
                     n_inj[i][mask],
                     cs2_inj[i][mask],
@@ -1263,7 +1288,8 @@ def make_cs2_plot(
     ylabel = r"$c_s^2$" if TEX_ENABLED else "cs2"
     plt.xlabel(xlabel)
     plt.ylabel(ylabel)
-    plt.xlim(0.5, 6.0)
+    # NOTE: we limit at 6 nsat since that is where most interesting things happen
+    plt.xlim(left=0.5, right=6.0)
     plt.ylim(0.0, 1.2)  # Speed of sound squared should be between 0 and 1 (c=1)
 
     # Add legend for prior and/or injection
@@ -1299,6 +1325,7 @@ def make_cs2_plot(
 
 
 # TODO: Fill histograms between the credible interval edges and not fill outside of it
+# TODO: Would be cool to see prior_data actually being used (we never do that) or just completely gone in a future PR
 def make_parameter_histograms(
     data: Dict[str, Any],
     prior_data: Optional[Dict[str, Any]],
@@ -1330,6 +1357,7 @@ def make_parameter_histograms(
         [np.interp(1.4, mass, lambda_arr) for mass, lambda_arr in zip(m, l)]
     )
     p3nsat_list = np.array([np.interp(3.0, dens, press) for dens, press in zip(n, p)])
+    n_TOV_list = data.get("n_TOV", None)
 
     # Calculate prior parameters if available
     prior_params = {}
@@ -1354,6 +1382,8 @@ def make_parameter_histograms(
         prior_params["p3nsat"] = np.array(
             [np.interp(3.0, dens, press) for dens, press in zip(n_prior, p_prior)]
         )
+        if "n_TOV" in prior_data:
+            prior_params["n_TOV"] = prior_data["n_TOV"]
 
     # Calculate injection parameters if available
     injection_params = {}
@@ -1372,6 +1402,9 @@ def make_parameter_histograms(
             n_inj, p_inj = injection_data["n"], injection_data["p"]
             injection_params["p3nsat"] = np.interp(3.0, n_inj[0], p_inj[0])
 
+        if "n_TOV" in injection_data:
+            injection_params["n_TOV"] = injection_data["n_TOV"][0]
+
     # Define parameters to plot (without fixed ranges)
     if TEX_ENABLED:
         parameters = {
@@ -1383,6 +1416,11 @@ def make_parameter_histograms(
                 "xlabel": r"$p(3n_{\rm{sat}})$ [MeV fm$^{-3}$]",
             },
         }
+        if n_TOV_list is not None:
+            parameters["n_TOV"] = {
+                "values": n_TOV_list,
+                "xlabel": r"$n_{\rm{TOV}}$ [$n_{\rm{sat}}$]",
+            }
     else:
         parameters = {
             "MTOV": {"values": MTOV_list, "xlabel": "M_TOV [M_sun]"},
@@ -1390,6 +1428,11 @@ def make_parameter_histograms(
             "Lambda14": {"values": Lambda14_list, "xlabel": "Lambda_1.4"},
             "p3nsat": {"values": p3nsat_list, "xlabel": "p(3n_sat) [MeV fm^-3]"},
         }
+        if n_TOV_list is not None:
+            parameters["n_TOV"] = {
+                "values": n_TOV_list,
+                "xlabel": "n_TOV [n_sat]",
+            }
 
     for param_name, param_data in parameters.items():
         plt.figure(figsize=figsize_horizontal)

--- a/jesterTOV/inference/postprocessing/postprocessing.py
+++ b/jesterTOV/inference/postprocessing/postprocessing.py
@@ -1022,8 +1022,11 @@ def make_pressure_density_plot(
     # Plot prior first (background)
     if prior_data is not None:
         n_prior, p_prior = prior_data["densities"], prior_data["pressures"]
+        n_TOV_prior = prior_data.get("n_TOV", None)
         for i in range(len(n_prior)):
             mask = n_prior[i] > 0.5
+            if n_TOV_prior is not None:
+                mask = mask & (n_prior[i] <= n_TOV_prior[i])
             plt.plot(
                 n_prior[i][mask],
                 p_prior[i][mask],
@@ -1188,8 +1191,11 @@ def make_cs2_plot(
     # Plot prior first (background)
     if prior_data is not None:
         n_prior, cs2_prior = prior_data["densities"], prior_data["cs2"]
+        n_TOV_prior = prior_data.get("n_TOV", None)
         for i in range(len(n_prior)):
             mask = n_prior[i] > 0.5
+            if n_TOV_prior is not None:
+                mask = mask & (n_prior[i] <= n_TOV_prior[i])
             plt.plot(
                 n_prior[i][mask],
                 cs2_prior[i][mask],
@@ -1357,7 +1363,12 @@ def make_parameter_histograms(
         [np.interp(1.4, mass, lambda_arr) for mass, lambda_arr in zip(m, l)]
     )
     p3nsat_list = np.array([np.interp(3.0, dens, press) for dens, press in zip(n, p)])
-    n_TOV_list = data.get("n_TOV", None)
+    _n_TOV_raw = data.get("n_TOV", None)
+    n_TOV_list = (
+        np.array(_n_TOV_raw)[np.array(_n_TOV_raw) > 0.0]
+        if _n_TOV_raw is not None
+        else None
+    )
 
     # Calculate prior parameters if available
     prior_params = {}
@@ -1383,7 +1394,8 @@ def make_parameter_histograms(
             [np.interp(3.0, dens, press) for dens, press in zip(n_prior, p_prior)]
         )
         if "n_TOV" in prior_data:
-            prior_params["n_TOV"] = prior_data["n_TOV"]
+            _n_TOV_prior_raw = np.array(prior_data["n_TOV"])
+            prior_params["n_TOV"] = _n_TOV_prior_raw[_n_TOV_prior_raw > 0.0]
 
     # Calculate injection parameters if available
     injection_params = {}

--- a/jesterTOV/inference/result.py
+++ b/jesterTOV/inference/result.py
@@ -380,6 +380,7 @@ class InferenceResult:
             "p",
             "e",
             "cs2",
+            "n_TOV",
         }
         param_samples = {
             k: v for k, v in self.posterior.items() if k not in exclude_keys
@@ -507,6 +508,7 @@ class InferenceResult:
                 "p",
                 "e",
                 "cs2",
+                "n_TOV",
             }
             sampler_specific_keys = {"weights", "ess", "logL", "logL_birth"}
 
@@ -774,6 +776,7 @@ class InferenceResult:
                 "p",
                 "e",
                 "cs2",
+                "n_TOV",
                 "_sampler_specific",
             }
         ]

--- a/jesterTOV/inference/result.py
+++ b/jesterTOV/inference/result.py
@@ -422,7 +422,16 @@ class InferenceResult:
 
         # Add transformed outputs to posterior (EOS quantities only, not input parameters)
         # Filter out input parameters from transformed_samples to avoid overwriting full posterior arrays
-        eos_keys = {"masses_EOS", "radii_EOS", "Lambdas_EOS", "n", "p", "e", "cs2"}
+        eos_keys = {
+            "masses_EOS",
+            "radii_EOS",
+            "Lambdas_EOS",
+            "n",
+            "p",
+            "e",
+            "cs2",
+            "n_TOV",
+        }
         eos_only = {k: v for k, v in transformed_samples.items() if k in eos_keys}
         self.add_derived_eos(eos_only)
 

--- a/jesterTOV/inference/transforms/transform.py
+++ b/jesterTOV/inference/transforms/transform.py
@@ -386,6 +386,11 @@ class JesterTransform(NtoMTransform):
             extra_constraints=eos_data.extra_constraints,
         )
 
+        # n_TOV: maximum density inside a NS, reached at MTOV.
+        pc_TOV = jnp.power(10.0, family_data.log10pcs[-1])
+        n_TOV = jnp.interp(pc_TOV, eos_data.ps, eos_data.ns)
+        result["n_TOV"] = jnp.nan_to_num(n_TOV, nan=0.0, posinf=0.0, neginf=0.0)
+
         return result
 
     def _create_return_dict(

--- a/tests/test_inference/test_postprocessing.py
+++ b/tests/test_inference/test_postprocessing.py
@@ -16,6 +16,7 @@ from jesterTOV.inference.postprocessing.postprocessing import (
     make_mass_radius_plot,
     make_pressure_density_plot,
     make_cs2_plot,
+    make_parameter_histograms,
 )
 from jesterTOV.inference.result import InferenceResult
 
@@ -61,6 +62,7 @@ class TestLoadEOSData:
             "p": np.random.rand(2, 50),
             "e": np.random.rand(2, 50),
             "cs2": np.random.rand(2, 50),
+            "n_TOV": np.array([1e45, 2e45]),  # geometric units
         }
         metadata = {
             "sampler": "flowmc",
@@ -87,11 +89,13 @@ class TestLoadEOSData:
         assert "pressures" in data  # renamed from p
         assert "energies" in data  # renamed from e
         assert "cs2" in data
+        assert "n_TOV" in data
         assert "log_prob" in data
 
         # Verify shapes preserved (note: densities/pressures have unit conversions applied)
         assert data["masses"].shape == (2, 100)
         assert data["densities"].shape == (2, 50)
+        assert data["n_TOV"].shape == (2,)  # scalar per sample
 
     def test_load_eos_data_file_not_found(self, temp_dir):
         """Test that load_eos_data raises FileNotFoundError for missing file."""
@@ -211,6 +215,7 @@ class TestPlotGeneration:
             "pressures": np.random.uniform(1.0, 100.0, (n_samples, n_eos_points)),
             "energies": np.random.uniform(1.0, 500.0, (n_samples, n_eos_points)),
             "cs2": np.random.uniform(0.0, 1.0, (n_samples, n_eos_points)),
+            "n_TOV": np.random.uniform(2.5, 6.0, n_samples),  # in n_sat units
             "log_prob": np.random.uniform(-50.0, -10.0, n_samples),
             # Use "prior_params" as returned by load_eos_data (not "nep_params")
             "prior_params": {
@@ -327,6 +332,103 @@ class TestPlotGeneration:
 
         plt.close("all")
 
+    def test_make_parameter_histograms_n_TOV(self, mock_data, temp_dir):
+        """Test that make_parameter_histograms creates n_TOV histogram when n_TOV present."""
+        make_parameter_histograms(data=mock_data, prior_data=None, outdir=str(temp_dir))
+
+        expected_file = temp_dir / "n_TOV_histogram.pdf"
+        assert (
+            expected_file.exists()
+        ), "n_TOV histogram should be created when n_TOV is in data"
+
+        plt.close("all")
+
+    def test_make_parameter_histograms_without_n_TOV(self, mock_data, temp_dir):
+        """Test that make_parameter_histograms works without n_TOV (backwards compat)."""
+        data_without_n_TOV = {k: v for k, v in mock_data.items() if k != "n_TOV"}
+        make_parameter_histograms(
+            data=data_without_n_TOV, prior_data=None, outdir=str(temp_dir)
+        )
+
+        # n_TOV histogram should NOT be created
+        assert not (temp_dir / "n_TOV_histogram.pdf").exists()
+        # But other histograms should still be created
+        assert (temp_dir / "MTOV_histogram.pdf").exists()
+
+        plt.close("all")
+
+    def test_pressure_density_plot_uses_n_TOV_for_truncation(self, temp_dir):
+        """Test that p(n) curves are truncated at n_TOV."""
+        n_samples = 5
+        n_eos_points = 100
+        # Densities from 0 to 8 n_sat
+        densities = np.tile(np.linspace(0, 8, n_eos_points), (n_samples, 1))
+        pressures = np.tile(np.linspace(0.1, 1000, n_eos_points), (n_samples, 1))
+        n_TOV = np.full(n_samples, 3.0)  # truncate at 3 n_sat
+
+        data = {
+            "masses": np.random.uniform(1.0, 2.5, (n_samples, n_eos_points)),
+            "radii": np.random.uniform(10.0, 15.0, (n_samples, n_eos_points)),
+            "lambdas": np.random.uniform(100.0, 1000.0, (n_samples, n_eos_points)),
+            "densities": densities,
+            "pressures": pressures,
+            "n_TOV": n_TOV,
+            "log_prob": np.full(n_samples, -10.0),
+            "prior_params": {},
+        }
+
+        make_pressure_density_plot(data=data, prior_data=None, outdir=str(temp_dir))
+        assert (temp_dir / "pressure_density_plot.pdf").exists()
+        plt.close("all")
+
+    def test_cs2_plot_uses_n_TOV_for_truncation(self, temp_dir):
+        """Test that cs2(n) curves are truncated at n_TOV."""
+        n_samples = 5
+        n_eos_points = 100
+        densities = np.tile(np.linspace(0, 8, n_eos_points), (n_samples, 1))
+        cs2 = np.tile(np.linspace(0.0, 0.8, n_eos_points), (n_samples, 1))
+        n_TOV = np.full(n_samples, 3.0)
+
+        data = {
+            "masses": np.random.uniform(1.0, 2.5, (n_samples, n_eos_points)),
+            "radii": np.random.uniform(10.0, 15.0, (n_samples, n_eos_points)),
+            "lambdas": np.random.uniform(100.0, 1000.0, (n_samples, n_eos_points)),
+            "densities": densities,
+            "cs2": cs2,
+            "n_TOV": n_TOV,
+            "log_prob": np.full(n_samples, -10.0),
+            "prior_params": {},
+        }
+
+        make_cs2_plot(data=data, prior_data=None, outdir=str(temp_dir))
+        assert (temp_dir / "cs2_density_plot.pdf").exists()
+        plt.close("all")
+
+    def test_plots_skip_invalid_n_TOV_zero(self, temp_dir):
+        """Test that samples with n_TOV=0 (failed computation) are skipped."""
+        n_samples = 5
+        n_eos_points = 100
+        densities = np.tile(np.linspace(0, 8, n_eos_points), (n_samples, 1))
+        pressures = np.tile(np.linspace(0.1, 1000, n_eos_points), (n_samples, 1))
+        # One sample has n_TOV=0 (nan_to_num fallback for failed EOS)
+        n_TOV = np.array([3.0, 0.0, 4.0, 3.5, 2.5])
+
+        data = {
+            "masses": np.random.uniform(1.0, 2.5, (n_samples, n_eos_points)),
+            "radii": np.random.uniform(10.0, 15.0, (n_samples, n_eos_points)),
+            "lambdas": np.random.uniform(100.0, 1000.0, (n_samples, n_eos_points)),
+            "densities": densities,
+            "pressures": pressures,
+            "n_TOV": n_TOV,
+            "log_prob": np.full(n_samples, -10.0),
+            "prior_params": {},
+        }
+
+        # Should not crash; the zero-n_TOV sample is silently skipped
+        make_pressure_density_plot(data=data, prior_data=None, outdir=str(temp_dir))
+        assert (temp_dir / "pressure_density_plot.pdf").exists()
+        plt.close("all")
+
 
 class TestPlotErrorHandling:
     """Test error handling in plotting functions."""
@@ -379,6 +481,7 @@ class TestIntegrationWithInferenceResult:
             "p": np.random.uniform(0.1, 500, (n_samples, n_eos)),
             "e": np.random.uniform(1, 1000, (n_samples, n_eos)),
             "cs2": np.random.uniform(0.0, 1.0, (n_samples, n_eos)),
+            "n_TOV": np.random.uniform(1e45, 5e45, n_samples),
         }
 
         metadata = {

--- a/tests/test_inference/test_transforms.py
+++ b/tests/test_inference/test_transforms.py
@@ -438,3 +438,101 @@ class TestSpectralTransform:
             "Spectral transform must include 'n_gamma_violations' for "
             "ConstraintGammaLikelihood to work correctly"
         )
+
+
+class TestNTOV:
+    """Tests for n_TOV computation in JesterTransform."""
+
+    @pytest.mark.slow
+    def test_n_TOV_present_in_output(self, realistic_nep_stiff):
+        """Test that n_TOV is present in transform output."""
+        eos_config = MetamodelEOSConfig(type="metamodel", ndat_metamodel=50, nb_CSE=0)
+        tov_config = GRTOVConfig(ndat_TOV=50)
+        transform = JesterTransform.from_config(eos_config, tov_config)
+
+        result = transform.forward(realistic_nep_stiff)
+
+        assert "n_TOV" in result, "n_TOV must be present in transform output"
+
+    @pytest.mark.slow
+    def test_n_TOV_is_scalar(self, realistic_nep_stiff):
+        """Test that n_TOV is a scalar (not an array)."""
+        eos_config = MetamodelEOSConfig(type="metamodel", ndat_metamodel=50, nb_CSE=0)
+        tov_config = GRTOVConfig(ndat_TOV=50)
+        transform = JesterTransform.from_config(eos_config, tov_config)
+
+        result = transform.forward(realistic_nep_stiff)
+
+        n_tov = result["n_TOV"]
+        assert (
+            jnp.ndim(n_tov) == 0
+        ), f"n_TOV should be scalar, got shape {jnp.shape(n_tov)}"
+
+    @pytest.mark.slow
+    def test_n_TOV_is_positive(self, realistic_nep_stiff):
+        """Test that n_TOV is positive for a valid EOS."""
+        eos_config = MetamodelEOSConfig(type="metamodel", ndat_metamodel=50, nb_CSE=0)
+        tov_config = GRTOVConfig(ndat_TOV=50)
+        transform = JesterTransform.from_config(eos_config, tov_config)
+
+        result = transform.forward(realistic_nep_stiff)
+
+        assert float(result["n_TOV"]) > 0.0, "n_TOV must be positive for valid EOS"
+
+    @pytest.mark.slow
+    def test_n_TOV_exceeds_MTOV_central_density(self, realistic_nep_stiff):
+        """Test that n_TOV is physically reasonable.
+
+        n_TOV should be the density at the central pressure of MTOV.
+        For realistic neutron stars, this should be 2-8 n_sat in geometric units.
+        """
+        from jesterTOV import utils
+
+        eos_config = MetamodelEOSConfig(type="metamodel", ndat_metamodel=50, nb_CSE=0)
+        tov_config = GRTOVConfig(ndat_TOV=50)
+        transform = JesterTransform.from_config(eos_config, tov_config)
+
+        result = transform.forward(realistic_nep_stiff)
+
+        n_TOV_nsat = float(result["n_TOV"]) / utils.fm_inv3_to_geometric / 0.16
+        # Typical MTOV central density is between 2 and 8 n_sat
+        assert (
+            1.0 < n_TOV_nsat < 10.0
+        ), f"n_TOV = {n_TOV_nsat:.2f} n_sat is outside expected range [1, 10] n_sat"
+
+    @pytest.mark.slow
+    def test_n_TOV_stored_in_hdf5(self, realistic_nep_stiff, tmp_path):
+        """Test that n_TOV is stored and retrieved from HDF5 results."""
+        import numpy as np
+        from jesterTOV.inference.result import InferenceResult
+
+        eos_config = MetamodelEOSConfig(type="metamodel", ndat_metamodel=50, nb_CSE=0)
+        tov_config = GRTOVConfig(ndat_TOV=50)
+        transform = JesterTransform.from_config(eos_config, tov_config)
+
+        result = transform.forward(realistic_nep_stiff)
+        n_TOV_val = float(result["n_TOV"])
+
+        # Build a minimal InferenceResult with n_TOV
+        posterior = {
+            "log_prob": np.array([-10.0]),
+            "masses_EOS": np.array([[1.4, 2.0]]),
+            "radii_EOS": np.array([[12.0, 11.0]]),
+            "Lambdas_EOS": np.array([[500.0, 100.0]]),
+            "n": np.array([[0.1, 0.5]]),
+            "p": np.array([[1.0, 10.0]]),
+            "e": np.array([[100.0, 500.0]]),
+            "cs2": np.array([[0.1, 0.4]]),
+            "n_TOV": np.array([n_TOV_val]),
+        }
+        metadata = {"sampler": "flowmc", "n_samples": 1}
+        inference_result = InferenceResult(
+            sampler_type="flowmc", posterior=posterior, metadata=metadata
+        )
+
+        filepath = tmp_path / "results.h5"
+        inference_result.save(filepath)
+
+        loaded = InferenceResult.load(filepath)
+        assert "n_TOV" in loaded.posterior
+        assert np.isclose(loaded.posterior["n_TOV"][0], n_TOV_val)


### PR DESCRIPTION
We did not save n_TOV but this would actually be convenient. At the same time, the computed/stored values can be used in postprocessing EOS plots to truncate at n_TOV. 

Note: accidentally first called it nbreak in a previous commit. git ammend did not change this, so i just decided to make this stupid small mistake eternal in the main branch git history

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added n_TOV parameter computation to EOS analyses
  * Parameter histograms now include n_TOV distributions when available
  * Pressure-density and sound speed plots now incorporate n_TOV-based density truncation for improved visualization accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->