### PR TITLE
Update proton fraction cubic root formulae

### DIFF
--- a/jesterTOV/eos/metamodel/base.py
+++ b/jesterTOV/eos/metamodel/base.py
@@ -694,19 +694,7 @@ class MetaModel_EOS_model(Interpolate_EOS_model):
         c = utils.hbarc * jnp.power(3.0 * jnp.pi**2 * n, 1.0 / 3.0)
         d = -4.0 * Esym - (utils.m_n - utils.m_p)
 
-        coeffs = jnp.array(
-            [
-                a,
-                b,
-                c,
-                d,
-            ]
-        ).T
+        coeffs = jnp.stack([a, b, c, d], axis=1)
         ys = utils.cubic_root_for_proton_fraction(coeffs)
-        physical_ys = jnp.where(
-            (ys.imag == 0.0) * (ys.real >= 0.0) * (ys.real <= 1.0),
-            ys.real,
-            jnp.zeros_like(ys.real),
-        ).sum(axis=1)
-        proton_fraction = jnp.power(physical_ys, 3)
+        proton_fraction = ys**3  # type: ignore[operator]
         return proton_fraction

--- a/jesterTOV/utils.py
+++ b/jesterTOV/utils.py
@@ -102,16 +102,17 @@ def cubic_root_for_proton_fraction(coefficients):
     """
     a, b, c, d = coefficients
 
-    # Monic form: y³ + a_nr·y² + b_nr·y + c_nr = 0
+    # Monic form: y^3 + a y^2 + b y + c = 0
     a_nr = b / a  # = 0 for our b=0 cubic
     b_nr = c / a  # = p = c/a
     c_nr = d / a  # = q = d/a
 
+    # Convert to the expression for numerical recipes (NR) from Press et al.:
     # NR Q, R  (for b=0: Q = -p/3, R = q/2)
     Q = (a_nr**2 - 3.0 * b_nr) / 9.0
     R = (2.0 * a_nr**3 - 9.0 * a_nr * b_nr + 27.0 * c_nr) / 54.0
 
-    # A, B formula  (D = R²-Q³ > 0 guaranteed when a > 0)
+    # A, B formula  (D = R^2 - Q^3 > 0 guaranteed when a > 0)
     inner = jnp.maximum(R**2 - Q**3, 0.0)  # clamp against floating-point noise
     A = -jnp.sign(R) * jnp.cbrt(jnp.abs(R) + jnp.sqrt(inner))
     B = jnp.where(A != 0.0, Q / A, 0.0)

--- a/jesterTOV/utils.py
+++ b/jesterTOV/utils.py
@@ -80,41 +80,44 @@ roots_vmap = vmap(partial(jnp.roots, strip_zeros=False), in_axes=0, out_axes=0)
 def cubic_root_for_proton_fraction(coefficients):
     r"""Solve cubic equation for proton fraction in beta-equilibrium.
 
-    This function solves the cubic equation that arises from the
-    beta-equilibrium condition in neutron star matter using Cardano's
-    formula for exact analytical solution. The cubic equation has the
-    form ax^3 + bx^2 + cx + d = 0, where the coefficients are related
-    to the symmetry energy and electron chemical potential.
+    Solves :math:`ay^3 + by^2 + cy + d = 0` for the real root
+    :math:`y = x_p^{1/3}` that satisfies :math:`y \in (0, 1)`.
 
-    This function is vectorized to handle multiple coefficient sets
-    simultaneously for different densities.
+    Uses the Numerical Recipes A,B branch (§5.6, Press et al.) which avoids
+    complex arithmetic. When :math:`E_{\rm sym} > 0` (i.e. :math:`a > 0`),
+    the discriminant :math:`D = R^2 - Q^3 > 0` is guaranteed, so the
+    three-root Viète branch is provably unreachable and omitted.
+
+    When :math:`a \le 0` (unphysical :math:`E_{\rm sym} \le 0`), the guard
+    returns ``0.0`` for all three negative-Esym sub-regimes, including the
+    large-negative-Esym case where the previous Cardano implementation
+    returned a spurious root near :math:`y = 1`.
 
     Args:
-        coefficients: Array of cubic polynomial coefficients [a, b, c, d]
+        coefficients: Array of cubic polynomial coefficients ``[a, b, c, d]``.
 
     Returns:
-        Array of three roots of the cubic equation (may be complex)
+        Real root :math:`y = x_p^{1/3}`, or ``0.0`` when no physical root
+        exists (:math:`E_{\rm sym} \le 0`).
     """
     a, b, c, d = coefficients
 
-    # Cardano's formula implementation
-    f = ((3.0 * c / a) - ((b**2) / (a**2))) / 3.0
-    g = (((2.0 * (b**3)) / (a**3)) - ((9.0 * b * c) / (a**2)) + (27.0 * d / a)) / 27.0
-    g_squared = g**2
-    f_cubed = f**3
-    h = g_squared / 4.0 + f_cubed / 27.0
+    # Monic form: y³ + a_nr·y² + b_nr·y + c_nr = 0
+    a_nr = b / a  # = 0 for our b=0 cubic
+    b_nr = c / a  # = p = c/a
+    c_nr = d / a  # = q = d/a
 
-    R = -(g / 2.0) + jnp.sqrt(h)
-    S = jnp.cbrt(R)
-    T = -(g / 2.0) - jnp.sqrt(h)
-    U = jnp.cbrt(T)
+    # NR Q, R  (for b=0: Q = -p/3, R = q/2)
+    Q = (a_nr**2 - 3.0 * b_nr) / 9.0
+    R = (2.0 * a_nr**3 - 9.0 * a_nr * b_nr + 27.0 * c_nr) / 54.0
 
-    # Three roots of the cubic equation
-    x1 = (S + U) - (b / (3.0 * a))
-    x2 = -(S + U) / 2 - (b / (3.0 * a)) + (S - U) * jnp.sqrt(3.0) * 0.5j
-    x3 = -(S + U) / 2 - (b / (3.0 * a)) - (S - U) * jnp.sqrt(3.0) * 0.5j
+    # A, B formula  (D = R²-Q³ > 0 guaranteed when a > 0)
+    inner = jnp.maximum(R**2 - Q**3, 0.0)  # clamp against floating-point noise
+    A = -jnp.sign(R) * jnp.cbrt(jnp.abs(R) + jnp.sqrt(inner))
+    B = jnp.where(A != 0.0, Q / A, 0.0)
+    root = (A + B) - a_nr / 3.0  # type: ignore[operator]
 
-    return jnp.array([x1, x2, x3])
+    return jnp.where(a > 0.0, root, 0.0)
 
 
 def cumtrapz(y, x):

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -316,6 +316,35 @@ class TestMetaModelEOSModel:
         assert jnp.all(yp >= 0.0)
         assert jnp.all(yp <= 0.5)
 
+    def test_metamodel_proton_fraction_large_negative_esym(self, metamodel_params):
+        """Proton fraction is 0 when Esym turns large-negative at high density.
+
+        When |Esym| > c/4 (≈ 140 MeV at n ≈ 0.79 fm⁻³) the discriminant D > 0
+        but the cubic has no root in (0, 1).  The old complex Cardano formula
+        returned a spurious value near xp = 1 in this regime; the NR A,B-only
+        solver must return 0 via the ``a > 0`` guard.
+
+        Reference: script 10 in internal-jester-review/proton_fraction/cardano/.
+        """
+        from jax.scipy.special import factorial
+
+        model = MetaModel_EOS_model(**metamodel_params)
+
+        # NEP set that drives Esym to ≈ −140 MeV at n ≈ 0.79 fm⁻³
+        # (K_sym and Z_sym at extreme ends of prior; matches script 09/10 cases)
+        params = jnp.array([36.5, 60.0, -400.0, -1000.0, -2000.0])
+        coeff_sym = params / factorial(jnp.arange(5))
+
+        n_test = jnp.linspace(0.08, 5 * 0.16, 200)
+        xp = model.compute_proton_fraction(coeff_sym, n_test)  # type: ignore[arg-type]
+
+        assert jnp.all(jnp.isfinite(xp)), "NaN/Inf in proton fraction output"
+        assert jnp.all(xp >= 0.0), "Negative proton fraction detected"
+        assert jnp.all(xp <= 0.5), (
+            f"Proton fraction exceeds 0.5; max={float(xp.max()):.4f}. "
+            "This indicates the spurious-root bug was not fixed."
+        )
+
 
 class TestMetaModelWithCSEEOSModel:
     """Test MetaModel with CSE extension."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -108,8 +108,87 @@ class TestCumtrapz:
             utils.cumtrapz(y, x)
 
 
-# NOTE: cubic_root_for_proton_fraction is tested within the EOS framework
-# where it's used for computing proton fractions, not as a standalone cubic solver
+class TestCubicRootForProtonFraction:
+    """Tests for the NR A,B-only cubic root solver used in proton fraction.
+
+    Covers the three physical regimes identified in the investigation:
+      1. Esym > 0  → one real root in (0, 1), returned correctly.
+      2. Esym < 0 (moderate, D < 0) → guard returns 0.
+      3. Esym << 0 (large negative, D > 0) → guard returns 0, not a
+         spurious root near y=1 (pre-existing bug in the Cardano formula).
+    """
+
+    def _make_coeffs(self, esym_mev: float, n_fm3: float):
+        """Build [a, b, c, d] coefficients for the beta-equilibrium cubic."""
+        a = jnp.array([8.0 * esym_mev])
+        b = jnp.array([0.0])
+        c = jnp.array([utils.hbarc * (3.0 * jnp.pi**2 * n_fm3) ** (1.0 / 3.0)])
+        d = jnp.array([-4.0 * esym_mev - (utils.m_n - utils.m_p)])
+        return jnp.stack([a, b, c, d], axis=1)  # shape [1, 4]
+
+    def test_physical_root_back_substitution(self):
+        """Root satisfies the polynomial to near machine precision when Esym > 0."""
+        esym = 32.0  # MeV, typical physical value
+        n = 0.32  # fm^-3, twice saturation density
+
+        coeffs = self._make_coeffs(esym, n)
+        y = utils.cubic_root_for_proton_fraction(coeffs)[0]
+
+        a, _, c, d = coeffs[0]
+        residual = float(jnp.abs(a * y**3 + c * y + d))
+        assert residual < 1e-8, f"back-substitution residual {residual:.2e} too large"
+
+    def test_physical_root_in_range(self):
+        """Root y = xp^(1/3) is in (0, 1) when Esym > 0."""
+        for esym in [28.0, 32.0, 45.0]:
+            for n in [0.16, 0.32, 0.64, 1.0]:
+                coeffs = self._make_coeffs(esym, n)
+                y = float(utils.cubic_root_for_proton_fraction(coeffs)[0])
+                assert 0.0 < y < 1.0, f"y={y} out of (0,1) for Esym={esym}, n={n}"
+
+    def test_moderate_negative_esym_returns_zero(self):
+        """Guard returns 0 for moderately negative Esym (unphysical regime)."""
+        # Esym = -5 MeV: a < 0, guard fires immediately
+        coeffs = self._make_coeffs(-5.0, 0.32)
+        y = float(utils.cubic_root_for_proton_fraction(coeffs)[0])
+        assert y == 0.0
+
+    def test_large_negative_esym_returns_zero(self):
+        """Guard returns 0 for large negative Esym (spurious-root regime).
+
+        When |Esym| > c/4 the discriminant D > 0 and the old Cardano formula
+        returned a spurious real root near y = 1 (xp ≈ 1).  The NR A,B-only
+        formula with the a > 0 guard must return 0 instead.
+
+        The reference case is from script 10: n ≈ 0.79 fm⁻³, Esym ≈ -140 MeV,
+        where the old code gave xp ≈ 0.9995.
+        """
+        coeffs = self._make_coeffs(-140.0, 0.79)
+        y = float(utils.cubic_root_for_proton_fraction(coeffs)[0])
+        assert y == 0.0, (
+            f"Expected y=0 for large-negative Esym but got y={y:.4f}; "
+            "old Cardano formula returned a spurious root near y=1 here"
+        )
+
+    def test_zero_esym_returns_zero(self):
+        """Guard returns 0 at the boundary Esym = 0."""
+        coeffs = self._make_coeffs(0.0, 0.32)
+        y = float(utils.cubic_root_for_proton_fraction(coeffs)[0])
+        assert y == 0.0
+
+    def test_vectorized_over_densities(self):
+        """Vectorised call (multiple density points) has no NaN/Inf."""
+        esym = 32.0
+        n_arr = jnp.linspace(0.08, 0.8, 50)
+        a = 8.0 * esym * jnp.ones_like(n_arr)
+        b = jnp.zeros_like(n_arr)
+        c = utils.hbarc * jnp.power(3.0 * jnp.pi**2 * n_arr, 1.0 / 3.0)
+        d = (-4.0 * esym - (utils.m_n - utils.m_p)) * jnp.ones_like(n_arr)
+        coeffs = jnp.stack([a, b, c, d], axis=1)
+        ys = utils.cubic_root_for_proton_fraction(coeffs)
+        assert jnp.all(jnp.isfinite(ys)), "NaN/Inf in vectorised output"  # type: ignore[arg-type]
+        assert jnp.all(ys >= 0.0)  # type: ignore[operator]
+        assert jnp.all(ys <= 1.0)  # type: ignore[operator]
 
 
 class TestLimitByMTOV:


### PR DESCRIPTION
The current proton fraction calculation is unstable and can give odd behavior at large densities in the metamodel. Inference runs are minimally impacted since this is expected to occur in very extreme cases and seemingly also mainly in high-density metamodel cases which we never probe with MM+CSE... Still, it's not good.

I switched things and implemented the formulae recommended in the "Numerical Recipes" handbook, which seem to be more stable. The current implementation avoids any complex arithmetic too, and has guard rails to avoid spurious roots to cause jumps in proton fraction again. 

Added tests to catch this behavior in the future. 

<img width="922" height="547" alt="image" src="https://github.com/user-attachments/assets/58adba4f-a4d3-4abd-bc0d-fb25c12ae840" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numerical stability of proton fraction calculations, particularly for extreme symmetry energy parameter regimes.

* **Tests**
  * Added comprehensive test suite covering proton fraction calculations across density ranges and edge cases.
  * Added validation tests ensuring computed results remain physically bounded and finite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->