### PR TITLE
Update the dloge_dlogps interpolation to centered finite differences

### DIFF
--- a/jesterTOV/eos/base.py
+++ b/jesterTOV/eos/base.py
@@ -60,17 +60,15 @@ class Interpolate_EOS_model(ABC):
         # rhos = utils.calculate_rest_mass_density(es, ps)
 
         hs = utils.cumtrapz(ps / (es + ps), jnp.log(ps))  # enthalpy
-        dloge_dlogps = jnp.diff(jnp.log(e)) / jnp.diff(jnp.log(p))
-        dloge_dlogps = jnp.concatenate(
-            (
-                jnp.array(
-                    [
-                        dloge_dlogps.at[0].get(),
-                    ]
-                ),
-                dloge_dlogps,
-            )
-        )
+
+        # Centered finite differences for interior points, one-sided at boundaries.
+        loge = jnp.log(e)
+        logp = jnp.log(p)
+        interior = (loge[2:] - loge[:-2]) / (logp[2:] - logp[:-2])
+        left = (loge[1] - loge[0]) / (logp[1] - logp[0])
+        right = (loge[-1] - loge[-2]) / (logp[-1] - logp[-2])
+        dloge_dlogps = jnp.concatenate([left[None], interior, right[None]])
+
         return ns, ps, hs, es, dloge_dlogps
 
     @abstractmethod


### PR DESCRIPTION
Turns out this small change to the `dloge_dlogp` calculation can give us a 2% improvement in RMS against the lalsuite TOV solver, bringing the median now to 0.2%. Thanks Claude!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of equation of state calculations through refined numerical differentiation methods used during interpolation operations. Enhanced derivative computation ensures more precise results at boundary and interior data points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->