### PR TITLE
Adding more safety to postprocessing.py in case no TeX available

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ This file provides guidance to Claude Code when working with the JESTER reposito
 
 **Backwards compatibility**: There has not been a release yet, so don't worry about breaking changes for now. Focus on code quality, testing, and documentation over supporting legacy APIs!
 
+**Postprocessing plots**: Every `make_*` plot call in `generate_all_plots` (`jesterTOV/inference/postprocessing/postprocessing.py`) must be wrapped in a `try/except Exception` block so that a missing LaTeX installation or any other rendering failure does not abort the full postprocessing run. See `jesterTOV/inference/CLAUDE.md` for the required pattern. LaTeX availability is checked with `shutil.which("latex")` in `setup_matplotlib` and TeX rendering is disabled globally when it is absent.
+
 **Extending JESTER**: When users mention working on adding new components, refer them to the relevant developer guide:
 - **Adding a new EOS model**: See `docs/developer_guide/adding_new_eos.md` for complete checklist (EOS class, schema updates, factory registration, tests, documentation)
 - **Adding a new TOV solver**: See `docs/developer_guide/adding_new_tov.md` for complete checklist (solver class, schema updates, factory registration, tests, documentation)

--- a/jesterTOV/inference/CLAUDE.md
+++ b/jesterTOV/inference/CLAUDE.md
@@ -6,6 +6,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - You do not know everything about samplers. Instead of just doing something that "seems right", please ask more information about samplers and best practices. We can provide src code. *Better to ask for help than to make wrong assumptions and write sloppy code!*
 - **blackjax**: For this, the src code is available at `/Users/Woute029/Documents/Code/projects/jester_review/blackjax`: use this to understand how to properly use blackjax samplers and best practices!
+- **Postprocessing plot functions**: Every `make_*` plot function call in `generate_all_plots` (in `postprocessing/postprocessing.py`) **must** be wrapped in a `try/except Exception` block that logs the error and continues. This ensures a missing LaTeX installation or any other rendering failure does not abort the entire postprocessing run. The pattern is:
+  ```python
+  try:
+      make_my_plot(...)
+  except Exception as e:
+      logger.error(f"Failed to create my plot: {e}")
+      logger.warning("Continuing with other plots...")
+  ```
 
 ## Module Overview
 

--- a/jesterTOV/inference/postprocessing/postprocessing.py
+++ b/jesterTOV/inference/postprocessing/postprocessing.py
@@ -10,6 +10,7 @@ Usage::
 """
 
 import re
+import shutil
 import sys
 import os
 import warnings
@@ -48,24 +49,30 @@ def setup_matplotlib(use_tex: bool = True) -> bool:
     """
     tex_enabled = False
     if use_tex:
-        try:
-            plt.rcParams.update(
-                {
-                    "text.usetex": True,
-                    "font.family": "serif",
-                    "font.serif": ["Computer Modern Serif"],
-                }
-            )
-            fig, ax = plt.subplots()
-            ax.text(0.5, 0.5, r"$\alpha$")
-            plt.close(fig)
-            tex_enabled = True
-            logger.info("TeX rendering enabled")
-        except Exception as e:
+        if shutil.which("latex") is None:
             warnings.warn(
-                f"TeX rendering failed ({e}). Falling back to non-TeX rendering."
+                "latex binary not found on PATH. Falling back to non-TeX rendering."
             )
             plt.rcParams.update({"text.usetex": False, "font.family": "sans-serif"})
+        else:
+            try:
+                plt.rcParams.update(
+                    {
+                        "text.usetex": True,
+                        "font.family": "serif",
+                        "font.serif": ["Computer Modern Serif"],
+                    }
+                )
+                fig, _ = plt.subplots()
+                fig.canvas.draw()
+                plt.close(fig)
+                tex_enabled = True
+                logger.info("TeX rendering enabled")
+            except Exception as e:
+                warnings.warn(
+                    f"TeX rendering failed ({e}). Falling back to non-TeX rendering."
+                )
+                plt.rcParams.update({"text.usetex": False, "font.family": "sans-serif"})
 
     plt.rcParams.update(
         {
@@ -1563,33 +1570,67 @@ def generate_all_plots(
             logger.warning("Continuing with other plots...")
 
     if make_massradius_flag:
-        make_mass_radius_plot(
-            data, prior_data, figures_dir, injection_data=injection_data
-        )
+        try:
+            make_mass_radius_plot(
+                data, prior_data, figures_dir, injection_data=injection_data
+            )
+        except Exception as e:
+            logger.error(f"Failed to create mass-radius plot: {e}")
+            logger.warning("Continuing with other plots...")
 
     if make_masslambda_flag:
-        make_mass_lambda_plot(
-            data, prior_data, figures_dir, injection_data=injection_data
-        )
+        try:
+            make_mass_lambda_plot(
+                data, prior_data, figures_dir, injection_data=injection_data
+            )
+        except Exception as e:
+            logger.error(f"Failed to create mass-Lambda plot: {e}")
+            logger.warning("Continuing with other plots...")
         if injection_data is not None:
-            make_mass_lambda_ratio_plot(data, figures_dir, injection_data)
+            try:
+                make_mass_lambda_ratio_plot(data, figures_dir, injection_data)
+            except Exception as e:
+                logger.error(f"Failed to create mass-Lambda ratio plot: {e}")
+                logger.warning("Continuing with other plots...")
 
     if make_pressuredensity_flag:
-        make_pressure_density_plot(
-            data, prior_data, figures_dir, injection_data=injection_data
-        )
+        try:
+            make_pressure_density_plot(
+                data, prior_data, figures_dir, injection_data=injection_data
+            )
+        except Exception as e:
+            logger.error(f"Failed to create pressure-density plot: {e}")
+            logger.warning("Continuing with other plots...")
 
     if make_histograms_flag:
-        make_parameter_histograms(data, figures_dir, injection_data=injection_data)
+        try:
+            make_parameter_histograms(data, figures_dir, injection_data=injection_data)
+        except Exception as e:
+            logger.error(f"Failed to create parameter histograms: {e}")
+            logger.warning("Continuing with other plots...")
 
     if make_cs2_flag:
-        make_cs2_plot(data, prior_data, figures_dir, injection_data=injection_data)
+        try:
+            make_cs2_plot(data, prior_data, figures_dir, injection_data=injection_data)
+        except Exception as e:
+            logger.error(f"Failed to create cs2 plot: {e}")
+            logger.warning("Continuing with other plots...")
 
     if make_contours_flag:
-        make_contour_radii_plot(data, prior_data, figures_dir)
-        make_contour_pressures_plot(data, figures_dir)
+        try:
+            make_contour_radii_plot(data, prior_data, figures_dir)
+        except Exception as e:
+            logger.error(f"Failed to create radii contour plot: {e}")
+            logger.warning("Continuing with other plots...")
+        try:
+            make_contour_pressures_plot(data, figures_dir)
+        except Exception as e:
+            logger.error(f"Failed to create pressures contour plot: {e}")
+            logger.warning("Continuing with other plots...")
 
-    logger.info(f"All plots generated and saved to {figures_dir}")
+    logger.info(
+        f"All plotting scripts executed and generated plots saved to {figures_dir}"
+    )
 
 
 def run_from_config(config_path: str) -> None:

--- a/jesterTOV/inference/postprocessing/postprocessing.py
+++ b/jesterTOV/inference/postprocessing/postprocessing.py
@@ -64,6 +64,7 @@ def setup_matplotlib(use_tex: bool = True) -> bool:
                     }
                 )
                 fig, _ = plt.subplots()
+                fig.text(0.5, 0.5, r"$x$")
                 fig.canvas.draw()
                 plt.close(fig)
                 tex_enabled = True


### PR DESCRIPTION
In case no LaTeX installation is available (such as on Google Colab), the current postprocessing functions fail. Updated the check for TeX installation availability, and just to be sure, also added more try-except guardrails in case an error occurs in any plotting function (not just the cornerplot) to ensure jester at least finishes successfully (even if that means without making plots). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plot generation failures no longer abort the entire postprocessing run; individual failures are logged and the process continues generating remaining plots.
  * Added graceful handling for missing LaTeX; rendering automatically falls back to non-TeX defaults when LaTeX is unavailable.

* **Documentation**
  * Updated postprocessing guidelines for robust plot generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->