### PR TITLE
Pass plot_format in run_inference.py

### DIFF
--- a/examples/inference/smc_random_walk/prior/config.yaml
+++ b/examples/inference/smc_random_walk/prior/config.yaml
@@ -33,6 +33,7 @@ sampler:
   output_dir: ./outdir/
 
 postprocessing:
+  plot_format: "png"
   enabled: true
   make_cornerplot: false
   make_massradius: true

--- a/jesterTOV/inference/run_inference.py
+++ b/jesterTOV/inference/run_inference.py
@@ -854,6 +854,7 @@ def main(config_path: str) -> None:
             make_histograms_flag=config.postprocessing.make_histograms,
             make_cs2_flag=config.postprocessing.make_cs2,
             injection_eos_path=config.postprocessing.injection_eos_path,
+            plot_format=config.postprocessing.plot_format,
         )
         logger.info(f"\nPostprocessing complete! Plots saved to {outdir}")
 


### PR DESCRIPTION
Missed passing it here so adding it now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable plot output format option for inference results. Users can now specify the desired plot format (e.g., PNG) through configuration settings, with the inference system respecting this preference when generating visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->