### PR TITLE
Update blackjax dependency to specific commit in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pandas>=2.0.0",
     "equinox>=0.11.0",
     "flowmc==0.4.5",
-    "blackjax @ git+https://github.com/handley-lab/blackjax@nested_sampling",
+    "blackjax @ git+https://github.com/handley-lab/blackjax.git@1e6ad99c971ba284f45c6af5931ab6f87ae9c896",
     "h5py>=3.0",
     "anesthetic>=2.0.0",
     "beartype>=0.10.0",


### PR DESCRIPTION
Newer blackjax in pyproject.toml requires jax ">=0.9.0". This point the dependency to specific compatible commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a project dependency to a pinned version for improved stability and consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nuclear-multimessenger-astronomy/jester/pull/152)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->