### PR TITLE
Small fixes for blackjax

### DIFF
--- a/jesterTOV/inference/samplers/blackjax/smc/base.py
+++ b/jesterTOV/inference/samplers/blackjax/smc/base.py
@@ -492,6 +492,12 @@ class BlackjaxSMCSampler(BlackjaxSampler):
         assert self._weights is not None
         ess = jnp.sum(self._weights) ** 2 / jnp.sum(self._weights**2)
 
+        # Resample to uniform weights so saved particles are i.i.d. posterior draws.
+        key, resample_key = jax.random.split(key)
+        resample_idx = systematic(resample_key, self._weights, self.config.n_particles)
+        self._particles_flat = self._particles_flat[resample_idx]
+        self._weights = jnp.ones(self.config.n_particles) / self.config.n_particles
+
         # Compute summary statistics
         mean_ess = float(jnp.mean(ess_history[:steps]))
         min_ess = float(jnp.min(ess_history[:steps]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pandas>=2.0.0",
     "equinox>=0.11.0",
     "flowmc==0.4.5",
-    "blackjax @ git+https://github.com/handley-lab/blackjax.git@1e6ad99c971ba284f45c6af5931ab6f87ae9c896",
+    "blackjax @ git+https://github.com/ThibeauWouters/blackjax.git@jester",
     "h5py>=3.0",
     "anesthetic>=2.0.0",
     "beartype>=0.10.0",

--- a/uv.lock
+++ b/uv.lock
@@ -306,7 +306,7 @@ wheels = [
 [[package]]
 name = "blackjax"
 version = "0.1.0b1.dev82+g1e6ad99c9"
-source = { git = "https://github.com/handley-lab/blackjax?rev=nested_sampling#1e6ad99c971ba284f45c6af5931ab6f87ae9c896" }
+source = { git = "https://github.com/handley-lab/blackjax.git?rev=1e6ad99c971ba284f45c6af5931ab6f87ae9c896#1e6ad99c971ba284f45c6af5931ab6f87ae9c896" }
 dependencies = [
     { name = "fastprogress" },
     { name = "ipython" },
@@ -1455,7 +1455,7 @@ requires-dist = [
     { name = "astropy", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "beartype", specifier = ">=0.10.0" },
     { name = "bilby", marker = "extra == 'dev'", specifier = ">=2.0.0" },
-    { name = "blackjax", git = "https://github.com/handley-lab/blackjax?rev=nested_sampling" },
+    { name = "blackjax", git = "https://github.com/handley-lab/blackjax.git?rev=1e6ad99c971ba284f45c6af5931ab6f87ae9c896" },
     { name = "corner", specifier = ">=2.2.0" },
     { name = "diffrax" },
     { name = "equinox", specifier = ">=0.11.0" },


### PR DESCRIPTION
blackjax recently had a sign error bugfixed (check https://github.com/blackjax-devs/blackjax/pull/915/changes#diff-704d46086bb2659f264b16e184ddb193714c61972a37470aaee191eb49f96e6e). Also changing the handling of the SMC weights for completeness. Now pointing to my own blackjax since otherwise I have to fight CI/CD and I don't have the patience for that...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SMC sampler now applies final resampling step to particles and reweights them uniformly, enabling proper usage of samples as independent posterior draws in downstream analysis.

* **Chores**
  * Updated blackjax dependency source reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nuclear-multimessenger-astronomy/jester/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->