### PR TITLE
Minor modifications to radio timing setup

### DIFF
--- a/docs/inference/yaml_reference.md
+++ b/docs/inference/yaml_reference.md
@@ -419,15 +419,13 @@ Constrain neutron star masses using radio pulsar timing measurements. For the ph
     - name: "J0740+6620"
       mass_mean: 2.08
       mass_std: 0.07
-  penalty_value: -1e5           # Penalty for M_TOV ≤ m_min (optional, default: -1e5)
-  nb_masses: 100                # Number of mass points (optional, default: 100)
+  penalty_value: 0.0            # Penalty for M_TOV ≤ m_min (optional, default: 0.0)
 ```
 
 **Field Details:**
 
 - **`pulsars`** (`list[dict]`) - List of pulsars with `name`, `mass_mean`, and `mass_std` keys for Gaussian mass constraints
-- **`penalty_value`** (`float`, default: `-1e5`) - Log-likelihood penalty for invalid TOV solutions (M_TOV ≤ m_min)
-- **`nb_masses`** (`int`, default: `100`) - Number of mass points for numerical integration of Gaussian mass constraint
+- **`penalty_value`** (`float`, default: `0.0`) - Log-likelihood penalty for invalid TOV solutions (M_TOV ≤ m_min)
 
 ::::
 

--- a/examples/inference/anisotropy/GW170817/config.yaml
+++ b/examples/inference/anisotropy/GW170817/config.yaml
@@ -20,12 +20,12 @@ likelihoods:
 - type: radio
   enabled: true
   pulsars:
-  - name: J1614
-    mass_mean: 1.94
-    mass_std: 0.06
-  - name: J0740
+  - name: J1614-2230
+    mass_mean: 1.937
+    mass_std: 0.014
+  - name: J0740+6620
     mass_mean: 2.08
-    mass_std: 0.14
+    mass_std: 0.07
 - type: gw
   enabled: true
   events:

--- a/examples/inference/anisotropy/NICER_J0030/config.yaml
+++ b/examples/inference/anisotropy/NICER_J0030/config.yaml
@@ -20,12 +20,12 @@ likelihoods:
 - type: radio
   enabled: true
   pulsars:
-  - name: J1614
-    mass_mean: 1.94
-    mass_std: 0.06
-  - name: J0740
+  - name: J1614-2230
+    mass_mean: 1.937
+    mass_std: 0.014
+  - name: J0740+6620
     mass_mean: 2.08
-    mass_std: 0.14
+    mass_std: 0.07
 - type: nicer
   enabled: true
   pulsars:

--- a/examples/inference/anisotropy/NICER_J0740/config.yaml
+++ b/examples/inference/anisotropy/NICER_J0740/config.yaml
@@ -20,16 +20,16 @@ likelihoods:
 - type: radio
   enabled: true
   pulsars:
-  - name: J1614
-    mass_mean: 1.94
-    mass_std: 0.06
-  - name: J0740
+  - name: J1614-2230
+    mass_mean: 1.937
+    mass_std: 0.014
+  - name: J0740+6620
     mass_mean: 2.08
-    mass_std: 0.14
+    mass_std: 0.07
 - type: nicer
   enabled: true
   pulsars:
-  - name: J0740
+  - name: J0740+6620
     amsterdam_model_dir: ../../../../jesterTOV/inference/flows/models/nicer_maf/J07406620/amsterdam_gamma_nicerxmm
     maryland_model_dir: ../../../../jesterTOV/inference/flows/models/nicer_maf/J07406620/maryland_unknown_nicerxmm_rm
   N_masses_evaluation: 20

--- a/examples/inference/anisotropy/prior/config.yaml
+++ b/examples/inference/anisotropy/prior/config.yaml
@@ -14,7 +14,6 @@ tov:
   min_nsat_TOV: 0.75
   ndat_TOV: 100
   nb_masses: 100
-
 prior:
   specification_file: prior.prior
 

--- a/examples/inference/anisotropy/radio/config.yaml
+++ b/examples/inference/anisotropy/radio/config.yaml
@@ -20,12 +20,12 @@ likelihoods:
 - type: radio
   enabled: true
   pulsars:
-  - name: J1614
-    mass_mean: 1.94
-    mass_std: 0.06
-  - name: J0740
+  - name: J1614-2230
+    mass_mean: 1.937
+    mass_std: 0.014
+  - name: J0740+6620
     mass_mean: 2.08
-    mass_std: 0.14
+    mass_std: 0.07
 sampler:
   type: smc-rw
   n_particles: 5000

--- a/examples/inference/blackjax-ns-aw/NICER_J0740/config.yaml
+++ b/examples/inference/blackjax-ns-aw/NICER_J0740/config.yaml
@@ -20,7 +20,7 @@ likelihoods:
 - type: nicer
   enabled: true
   pulsars:
-  - name: J0740
+  - name: J0740+6620
     amsterdam_model_dir: ../../../../jesterTOV/inference/flows/models/nicer_maf/J07406620/amsterdam_gamma_nicerxmm
     maryland_model_dir: ../../../../jesterTOV/inference/flows/models/nicer_maf/J07406620/maryland_unknown_nicerxmm_rm
   N_masses_evaluation: 20

--- a/examples/inference/blackjax-ns-aw/radio/config.yaml
+++ b/examples/inference/blackjax-ns-aw/radio/config.yaml
@@ -20,13 +20,12 @@ likelihoods:
 - type: radio
   enabled: true
   pulsars:
-  - name: J1614
-    mass_mean: 1.94
-    mass_std: 0.06
-  - name: J0740
+  - name: J1614-2230
+    mass_mean: 1.937
+    mass_std: 0.014
+  - name: J0740+6620
     mass_mean: 2.08
-    mass_std: 0.14
-  nb_masses: 100
+    mass_std: 0.07
 sampler:
   type: blackjax-ns-aw
   n_live: 1400

--- a/examples/inference/flowmc/NICER_J0740/config.yaml
+++ b/examples/inference/flowmc/NICER_J0740/config.yaml
@@ -20,7 +20,7 @@ likelihoods:
 - type: nicer
   enabled: true
   pulsars:
-  - name: J0740
+  - name: J0740+6620
     amsterdam_model_dir: ../../../../jesterTOV/inference/flows/models/nicer_maf/J07406620/amsterdam_gamma_nicerxmm
     maryland_model_dir: ../../../../jesterTOV/inference/flows/models/nicer_maf/J07406620/maryland_unknown_nicerxmm_rm
   N_masses_evaluation: 20

--- a/examples/inference/flowmc/radio/config.yaml
+++ b/examples/inference/flowmc/radio/config.yaml
@@ -22,13 +22,12 @@ likelihoods:
 - type: radio
   enabled: true
   pulsars:
-  - name: J1614
-    mass_mean: 1.94
-    mass_std: 0.06
-  - name: J0740
+  - name: J1614-2230
+    mass_mean: 1.937
+    mass_std: 0.014
+  - name: J0740+6620
     mass_mean: 2.08
-    mass_std: 0.14
-  nb_masses: 100
+    mass_std: 0.07
 sampler:
   type: flowmc
   n_chains: 1000

--- a/examples/inference/mm_peakcse/GW170817/config.yaml
+++ b/examples/inference/mm_peakcse/GW170817/config.yaml
@@ -27,12 +27,12 @@ likelihoods:
 - type: radio
   enabled: true
   pulsars:
-  - name: J1614
-    mass_mean: 1.94
-    mass_std: 0.06
-  - name: J0740
+  - name: J1614-2230
+    mass_mean: 1.937
+    mass_std: 0.014
+  - name: J0740+6620
     mass_mean: 2.08
-    mass_std: 0.14
+    mass_std: 0.07
 sampler:
   type: smc-rw
   n_particles: 5000

--- a/examples/inference/mm_peakcse/NICER_J0740/config.yaml
+++ b/examples/inference/mm_peakcse/NICER_J0740/config.yaml
@@ -20,16 +20,16 @@ likelihoods:
 - type: radio
   enabled: true
   pulsars:
-  - name: J1614
-    mass_mean: 1.94
-    mass_std: 0.06
-  - name: J0740
+  - name: J1614-2230
+    mass_mean: 1.937
+    mass_std: 0.014
+  - name: J0740+6620
     mass_mean: 2.08
-    mass_std: 0.14
+    mass_std: 0.07
 - type: nicer
   enabled: true
   pulsars:
-  - name: J0740
+  - name: J0740+6620
     amsterdam_model_dir: ../../../../jesterTOV/inference/flows/models/nicer_maf/J07406620/amsterdam_gamma_nicerxmm
     maryland_model_dir: ../../../../jesterTOV/inference/flows/models/nicer_maf/J07406620/maryland_unknown_nicerxmm_rm
   N_masses_evaluation: 20

--- a/examples/inference/mm_peakcse/radio/config.yaml
+++ b/examples/inference/mm_peakcse/radio/config.yaml
@@ -20,12 +20,12 @@ likelihoods:
 - type: radio
   enabled: true
   pulsars:
-  - name: J1614
-    mass_mean: 1.94
-    mass_std: 0.06
-  - name: J0740
+  - name: J1614-2230
+    mass_mean: 1.937
+    mass_std: 0.014
+  - name: J0740+6620
     mass_mean: 2.08
-    mass_std: 0.14
+    mass_std: 0.07
 sampler:
   type: smc-rw
   n_particles: 5000

--- a/examples/inference/smc_random_walk/GW170817/config.yaml
+++ b/examples/inference/smc_random_walk/GW170817/config.yaml
@@ -27,12 +27,12 @@ likelihoods:
 - type: radio
   enabled: true
   pulsars:
-  - name: J1614
-    mass_mean: 1.94
-    mass_std: 0.06
-  - name: J0740
+  - name: J1614-2230
+    mass_mean: 1.937
+    mass_std: 0.014
+  - name: J0740+6620
     mass_mean: 2.08
-    mass_std: 0.14
+    mass_std: 0.07
 sampler:
   type: smc-rw
   n_particles: 5000

--- a/examples/inference/smc_random_walk/NICER_J0740/config.yaml
+++ b/examples/inference/smc_random_walk/NICER_J0740/config.yaml
@@ -20,16 +20,16 @@ likelihoods:
 - type: radio
   enabled: true
   pulsars:
-  - name: J1614
-    mass_mean: 1.94
-    mass_std: 0.06
-  - name: J0740
+  - name: J1614-2230
+    mass_mean: 1.937
+    mass_std: 0.014
+  - name: J0740+6620
     mass_mean: 2.08
-    mass_std: 0.14
+    mass_std: 0.07
 - type: nicer
   enabled: true
   pulsars:
-  - name: J0740
+  - name: J0740+6620
     amsterdam_model_dir: ../../../../jesterTOV/inference/flows/models/nicer_maf/J07406620/amsterdam_gamma_nicerxmm
     maryland_model_dir: ../../../../jesterTOV/inference/flows/models/nicer_maf/J07406620/maryland_unknown_nicerxmm_rm
   N_masses_evaluation: 20

--- a/examples/inference/smc_random_walk/radio/config.yaml
+++ b/examples/inference/smc_random_walk/radio/config.yaml
@@ -20,12 +20,12 @@ likelihoods:
 - type: radio
   enabled: true
   pulsars:
-  - name: J1614
-    mass_mean: 1.94
-    mass_std: 0.06
-  - name: J0740
+  - name: J1614-2230
+    mass_mean: 1.937
+    mass_std: 0.014
+  - name: J0740+6620
     mass_mean: 2.08
-    mass_std: 0.14
+    mass_std: 0.07
 sampler:
   type: smc-rw
   n_particles: 5000

--- a/examples/inference/spectral/NICER_J0740/config.yaml
+++ b/examples/inference/spectral/NICER_J0740/config.yaml
@@ -21,7 +21,7 @@ likelihoods:
 - type: nicer
   enabled: true
   pulsars:
-  - name: J0740
+  - name: J0740+6620
     amsterdam_model_dir: ../../../../jesterTOV/inference/flows/models/nicer_maf/J07406620/amsterdam_gamma_nicerxmm
     maryland_model_dir: ../../../../jesterTOV/inference/flows/models/nicer_maf/J07406620/maryland_unknown_nicerxmm_rm
   N_masses_evaluation: 20

--- a/examples/inference/spectral/radio/config.yaml
+++ b/examples/inference/spectral/radio/config.yaml
@@ -21,13 +21,12 @@ likelihoods:
 - type: radio
   enabled: true
   pulsars:
-  - name: J1614
-    mass_mean: 1.94
-    mass_std: 0.06
-  - name: J0740
+  - name: J1614-2230
+    mass_mean: 1.937
+    mass_std: 0.014
+  - name: J0740+6620
     mass_mean: 2.08
-    mass_std: 0.14
-  nb_masses: 100
+    mass_std: 0.07
 sampler:
   type: smc-rw
   n_particles: 1000

--- a/examples/inference/spectral/radio_low_mass/config.yaml
+++ b/examples/inference/spectral/radio_low_mass/config.yaml
@@ -24,7 +24,6 @@ likelihoods:
   - name: J0000
     mass_mean: 1.0
     mass_std: 0.1
-  nb_masses: 100
 sampler:
   type: smc-rw
   n_particles: 1000

--- a/examples/inference/spectral_reparam/radio/config.yaml
+++ b/examples/inference/spectral_reparam/radio/config.yaml
@@ -22,13 +22,12 @@ likelihoods:
 - type: radio
   enabled: true
   pulsars:
-  - name: J1614
-    mass_mean: 1.94
-    mass_std: 0.06
-  - name: J0740
+  - name: J1614-2230
+    mass_mean: 1.937
+    mass_std: 0.014
+  - name: J0740+6620
     mass_mean: 2.08
-    mass_std: 0.14
-  nb_masses: 100
+    mass_std: 0.07
 sampler:
   type: smc-rw
   n_particles: 1000

--- a/jesterTOV/inference/config/schemas/likelihoods.py
+++ b/jesterTOV/inference/config/schemas/likelihoods.py
@@ -494,8 +494,7 @@ class RadioLikelihoodConfig(BaseLikelihoodConfig):
             - name: "J0740+6620"
               mass_mean: 2.08
               mass_std: 0.07
-          penalty_value: -1e5
-          nb_masses: 100
+          penalty_value: 0.0
     """
 
     type: Literal["radio"] = Field(
@@ -511,14 +510,8 @@ class RadioLikelihoodConfig(BaseLikelihoodConfig):
     )
 
     penalty_value: float = Field(
-        default=-1e5,
+        default=0.0,
         description="Log-likelihood penalty for invalid TOV solutions (M_TOV ≤ m_min)",
-    )
-
-    nb_masses: int = Field(
-        default=100,
-        gt=0,
-        description="Number of mass points for numerical integration of Gaussian constraint",
     )
 
     @field_validator("pulsars")

--- a/jesterTOV/inference/likelihoods/radio.py
+++ b/jesterTOV/inference/likelihoods/radio.py
@@ -67,10 +67,11 @@ class RadioTimingLikelihood(LikelihoodBase):
     m_min : float, optional
         Minimum mass for the integration lower bound in solar masses. This should be
         well below any physical neutron star mass to avoid truncation effects.
+        Recommended to not touch this parameter.
         Default is 0.1 :math:`M_{\odot}`.
     penalty_value : float, optional
         Log-likelihood penalty for invalid TOV solutions (M_TOV ≤ m_min).
-        Default is -1e5.
+        Default is 0.0.
 
     Attributes
     ----------
@@ -123,14 +124,14 @@ class RadioTimingLikelihood(LikelihoodBase):
         psr_name: str,
         mean: float,
         std: float,
-        m_min: float = 0.1,  # TODO: determine if needs tuning later on
-        penalty_value: float = -1e5,
+        m_min: float = 0.1,
+        penalty_value: float = 0.0,
     ) -> None:
         super().__init__()
         self.psr_name = psr_name
         self.mean = mean
         self.std = std
-        self.m_min = m_min  # Minimum mass for integration (solar masses)
+        self.m_min = m_min
         self.penalty_value = penalty_value
 
     def evaluate(self, params: dict[str, Float | Array]) -> Float:

--- a/uv.lock
+++ b/uv.lock
@@ -305,8 +305,8 @@ wheels = [
 
 [[package]]
 name = "blackjax"
-version = "0.1.0b1.dev82+g1e6ad99c9"
-source = { git = "https://github.com/handley-lab/blackjax.git?rev=1e6ad99c971ba284f45c6af5931ab6f87ae9c896#1e6ad99c971ba284f45c6af5931ab6f87ae9c896" }
+version = "0.1.dev818+g8758ef11b"
+source = { git = "https://github.com/ThibeauWouters/blackjax.git?rev=jester#8758ef11be0b861bbf19fa806fe913e4d6774f50" }
 dependencies = [
     { name = "fastprogress" },
     { name = "ipython" },
@@ -1455,7 +1455,7 @@ requires-dist = [
     { name = "astropy", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "beartype", specifier = ">=0.10.0" },
     { name = "bilby", marker = "extra == 'dev'", specifier = ">=2.0.0" },
-    { name = "blackjax", git = "https://github.com/handley-lab/blackjax.git?rev=1e6ad99c971ba284f45c6af5931ab6f87ae9c896" },
+    { name = "blackjax", git = "https://github.com/ThibeauWouters/blackjax.git?rev=jester" },
     { name = "corner", specifier = ">=2.2.0" },
     { name = "diffrax" },
     { name = "equinox", specifier = ">=0.11.0" },


### PR DESCRIPTION
- Remove legacy fields that are unused
- Set penalty value to zero (for safety, negligible impact on the likelihood)
- Correct parameter values for PSRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Radio Pulsar Likelihood configuration documentation with revised default penalty handling for invalid TOV solutions.

* **Chores**
  * Updated all example configurations with corrected pulsar identifiers (J1614-2230, J0740+6620) and refined mass distribution parameters across inference workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->